### PR TITLE
CADC-9555 - move the call location for DataSource.clean_up from TodoR…

### DIFF
--- a/caom2pipe/astro_composable.py
+++ b/caom2pipe/astro_composable.py
@@ -156,7 +156,7 @@ def check_fits(fqn):
         logging.debug(f'No data in header when reading {fqn}')
     except (TypeError, OSError) as e3:
         logging.debug(traceback.format_exc())
-        logging.error(f'astropy getdata error {e2} when reading {fqn}')
+        logging.error(f'astropy getdata error {e3} when reading {fqn}')
         return False
 
     return True

--- a/caom2pipe/data_source_composable.py
+++ b/caom2pipe/data_source_composable.py
@@ -117,7 +117,7 @@ class DataSource(object):
             self._extensions = config.data_source_extensions
         self._logger = logging.getLogger(self.__class__.__name__)
 
-    def clean_up(self):
+    def clean_up(self, entry):
         pass
 
     def get_work(self):

--- a/caom2pipe/run_composable.py
+++ b/caom2pipe/run_composable.py
@@ -195,7 +195,6 @@ class TodoRunner(object):
         self._logger.debug('End _build_todo_list.')
 
     def _finish_run(self):
-        self._data_source.clean_up()
         mc.create_dir(self._config.log_file_directory)
         self._organizer.observable.rejected.persist_state()
         self._organizer.observable.metrics.capture()
@@ -241,6 +240,14 @@ class TodoRunner(object):
             self._logger.debug(traceback.format_exc())
             # keep processing the rest of the entries, so don't throw
             # this or any other exception at this point
+            result = -1
+        try:
+            self._data_source.clean_up(entry)
+        except Exception as e:
+            self._logger.info(
+                f'Cleanup failed for {storage_name.entry} with {e}'
+            )
+            self._logger.debug(traceback.format_exc())
             result = -1
         self._logger.debug(f'End _process_entry.')
         return result

--- a/caom2pipe/tests/config.yml
+++ b/caom2pipe/tests/config.yml
@@ -1,3 +1,14 @@
 working_directory: /usr/src/app/caom2pipe/caom2pipe/tests/data
-cache_file_name: test_cache.yml
-proxy_file_name: /usr/src/app/caom2pipe/caom2pipe/tests/data/test_proxy.pem
+netrc_filename: test_netrc
+proxy_file_name: test_proxy.pem
+resource_id: ivo://cadc.nrc.ca/sc2repo
+todo_file_name: todo.txt
+state_file_name: state.yml
+use_local_files: False
+logging_level: DEBUG
+archive: NEOSS
+collection: NEOSSAT
+features:
+  supports_composite: False
+  run_in_airflow: True
+  unexpected: False


### PR DESCRIPTION
…unner._finish_run to TodoRunner._process_entry, so that the cleanup happens one at a time, instead of the entire list of work to do.