### PR TITLE
CADC-10281 - treat fits2caom2 execution as a MetaVisit 

### DIFF
--- a/caom2pipe/astro_composable.py
+++ b/caom2pipe/astro_composable.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # ***********************************************************************
 # ******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 # *************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
@@ -424,7 +423,7 @@ def read_fits_data(fqn):
     return hdus
 
 
-class FilterMetadataCache(object):
+class FilterMetadataCache:
     """
     Cache the results of calls to the SVO filter service. As part of the
     caching, identify those filters that are not available from the service,

--- a/caom2pipe/caom_composable.py
+++ b/caom2pipe/caom_composable.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # ***********************************************************************
 # ******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 # *************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************

--- a/caom2pipe/client_composable.py
+++ b/caom2pipe/client_composable.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # ***********************************************************************
 # ******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 # *************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
@@ -122,7 +121,7 @@ __all__ = [
 ]
 
 
-class ClientCollection(object):
+class ClientCollection:
     """
     This class initializes and provides accessors to known HTTP clients
     for CADC services.

--- a/caom2pipe/data_source_composable.py
+++ b/caom2pipe/data_source_composable.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # ***********************************************************************
 # ******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 # *************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
@@ -97,7 +96,7 @@ __all__ = [
 ]
 
 
-class DataSource(object):
+class DataSource:
     """
     The mechanisms for identifying the lists of work to be done (otherwise
     known as which class instantiates the extension of the DataSource class)
@@ -156,7 +155,7 @@ class ListDirDataSource(DataSource):
     """
 
     def __init__(self, config, chooser):
-        super(ListDirDataSource, self).__init__(config)
+        super().__init__(config)
         self._chooser = chooser
         self._logger = logging.getLogger(self.__class__.__name__)
 
@@ -217,7 +216,7 @@ class ListDirSeparateDataSource(DataSource):
     """
 
     def __init__(self, config, recursive=True):
-        super(ListDirSeparateDataSource, self).__init__(config)
+        super().__init__(config)
         self._source_directories = config.data_sources
         self._extensions = config.data_source_extensions
         self._recursive = recursive
@@ -267,7 +266,7 @@ class ListDirTimeBoxDataSource(DataSource):
         :param config: manage_composable.Config
         :param recursive: True if sub-directories should also be checked
         """
-        super(ListDirTimeBoxDataSource, self).__init__(config)
+        super().__init__(config)
         self._source_directories = config.data_sources
         self._extensions = config.data_source_extensions
         self._recursive = recursive
@@ -332,7 +331,7 @@ class TodoFileDataSource(DataSource):
     """
 
     def __init__(self, config):
-        super(TodoFileDataSource, self).__init__(config)
+        super().__init__(config)
         self._logger = logging.getLogger(self.__class__.__name__)
 
     def get_work(self):
@@ -359,7 +358,7 @@ class QueryTimeBoxDataSource(DataSource):
     """
 
     def __init__(self, config, preview_suffix='jpg'):
-        super(QueryTimeBoxDataSource, self).__init__(config)
+        super().__init__(config)
         self._preview_suffix = preview_suffix
         subject = clc.define_subject(config)
         self._client = CadcTapClient(subject, resource_id=self._config.tap_id)
@@ -429,7 +428,7 @@ class QueryTimeBoxDataSourceTS(DataSource):
     """
 
     def __init__(self, config, preview_suffix='jpg'):
-        super(QueryTimeBoxDataSourceTS, self).__init__(config)
+        super().__init__(config)
         self._preview_suffix = preview_suffix
         subject = clc.define_subject(config)
         self._client = CadcTapClient(subject, resource_id=self._config.tap_id)
@@ -481,7 +480,7 @@ class UseLocalFilesDataSource(ListDirTimeBoxDataSource):
     For when use_local_files: True and cleanup_when_storing: True
     """
     def __init__(self, config, cadc_client, recursive=True):
-        super(UseLocalFilesDataSource, self).__init__(config)
+        super().__init__(config)
         self._cadc_client = cadc_client
         self._cleanup_when_storing = config.cleanup_files_when_storing
         self._cleanup_failure_directory = config.cleanup_failure_destination
@@ -531,7 +530,7 @@ class UseLocalFilesDataSource(ListDirTimeBoxDataSource):
         :param entry: os.DirEntry
         """
         copy_file = True
-        if super(UseLocalFilesDataSource, self).default_filter(entry):
+        if super().default_filter(entry):
             if entry.name.startswith('.'):
                 # skip dot files
                 copy_file = False
@@ -681,7 +680,7 @@ class VaultDataSource(ListDirTimeBoxDataSource):
     """
 
     def __init__(self, vault_client, config, recursive=True):
-        super(VaultDataSource, self).__init__(config, recursive)
+        super().__init__(config, recursive)
         self._vault_client = vault_client
         self._source_directories = config.data_sources
         self._data_source_extensions = config.data_source_extensions

--- a/caom2pipe/data_source_composable.py
+++ b/caom2pipe/data_source_composable.py
@@ -109,7 +109,7 @@ class DataSource:
         time-boxes for now, as it's the only in-use requirement)
     - a time-boxed directory listing
     - an implementation of the work_composable.work class, which returns a
-        list of work todo as a method implementation
+        deque of work todo as a method implementation
     """
 
     def __init__(self, config=None):
@@ -125,10 +125,10 @@ class DataSource:
         pass
 
     def get_work(self):
-        return []
+        return deque()
 
     def get_time_box_work(self, prev_exec_time, exec_time):
-        return []
+        return deque()
 
     @property
     def start_time_ts(self):
@@ -165,7 +165,7 @@ class ListDirDataSource(DataSource):
             f'{self.__class__.__name__}.'
         )
         file_list = os.listdir(self._config.working_directory)
-        work = []
+        work = deque()
         for f in file_list:
             f_name = None
             if f.endswith('.fits') or f.endswith('.fits.gz'):
@@ -200,7 +200,7 @@ class ListDirDataSource(DataSource):
                 self._logger.debug(f'{f_name} added to work list.')
                 work.append(f_name)
         # ensure unique entries
-        temp = list(set(work))
+        temp = deque(set(work))
         self._logger.debug(f'End get_work in {self.__class__.__name__}.')
         return temp
 
@@ -220,7 +220,7 @@ class ListDirSeparateDataSource(DataSource):
         self._source_directories = config.data_sources
         self._extensions = config.data_source_extensions
         self._recursive = recursive
-        self._work = []
+        self._work = deque()
         self._logger = logging.getLogger(self.__class__.__name__)
 
     def get_work(self):
@@ -339,7 +339,7 @@ class TodoFileDataSource(DataSource):
             f'Begin get_work from {self._config.work_fqn} in '
             f'{self.__class__.__name__}'
         )
-        work = []
+        work = deque()
         with open(self._config.work_fqn) as f:
             for line in f:
                 temp = line.strip()

--- a/caom2pipe/execute_composable.py
+++ b/caom2pipe/execute_composable.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # ***********************************************************************
 # ******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 # *************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
@@ -127,7 +126,7 @@ from caom2pipe import transfer_composable as tc
 __all__ = ['CaomExecute', 'OrganizeExecutes', 'OrganizeChooser']
 
 
-class CaomExecute(object):
+class CaomExecute:
     """Abstract class that defines the operations common to all Execute
     classes."""
 
@@ -459,7 +458,7 @@ class MetaCreate(CaomExecute):
         meta_visitors,
         observable,
     ):
-        super(MetaCreate, self).__init__(
+        super().__init__(
             config,
             mc.TaskType.INGEST,
             storage_name,
@@ -521,7 +520,7 @@ class MetaUpdate(CaomExecute):
         meta_visitors,
         observable,
     ):
-        super(MetaUpdate, self).__init__(
+        super().__init__(
             config,
             mc.TaskType.INGEST,
             storage_name,
@@ -589,7 +588,7 @@ class MetaDeleteCreate(CaomExecute):
         meta_visitors,
         observable,
     ):
-        super(MetaDeleteCreate, self).__init__(
+        super().__init__(
             config,
             mc.TaskType.INGEST,
             storage_name,
@@ -661,7 +660,7 @@ class MetaUpdateObservation(CaomExecute):
         meta_visitors,
         observable,
     ):
-        super(MetaUpdateObservation, self).__init__(
+        super().__init__(
             config,
             mc.TaskType.INGEST_OBS,
             storage_name,
@@ -745,7 +744,7 @@ class LocalMetaCreate(CaomExecute):
         meta_visitors,
         observable,
     ):
-        super(LocalMetaCreate, self).__init__(
+        super().__init__(
             config,
             mc.TaskType.INGEST,
             storage_name,
@@ -808,7 +807,7 @@ class LocalMetaDeleteCreate(CaomExecute):
         meta_visitors,
         observable,
     ):
-        super(LocalMetaDeleteCreate, self).__init__(
+        super().__init__(
             config,
             mc.TaskType.INGEST,
             storage_name,
@@ -875,7 +874,7 @@ class LocalMetaUpdate(CaomExecute):
         meta_visitors,
         observable,
     ):
-        super(LocalMetaUpdate, self).__init__(
+        super().__init__(
             config,
             mc.TaskType.INGEST,
             storage_name,
@@ -941,7 +940,7 @@ class MetaVisit(CaomExecute):
         meta_visitors,
         observable,
     ):
-        super(MetaVisit, self).__init__(
+        super().__init__(
             config,
             mc.TaskType.VISIT,
             storage_name,
@@ -1000,7 +999,7 @@ class DataVisit(CaomExecute):
         observable,
         transferrer,
     ):
-        super(DataVisit, self).__init__(
+        super().__init__(
             config,
             task_type=task_type,
             storage_name=storage_name,
@@ -1081,7 +1080,7 @@ class LocalDataVisit(DataVisit):
         data_visitors,
         observable,
     ):
-        super(LocalDataVisit, self).__init__(
+        super().__init__(
             config,
             storage_name=storage_name,
             cadc_client=cadc_client,
@@ -1128,7 +1127,7 @@ class DataScrape(DataVisit):
     """
 
     def __init__(self, config, storage_name, data_visitors, observable):
-        super(DataScrape, self).__init__(
+        super().__init__(
             config,
             storage_name,
             cadc_client=None,
@@ -1174,7 +1173,7 @@ class Store(CaomExecute):
         observable,
         transferrer,
     ):
-        super(Store, self).__init__(
+        super().__init__(
             config,
             mc.TaskType.STORE,
             storage_name,
@@ -1236,7 +1235,7 @@ class LocalStore(Store):
         cadc_client,
         observable,
     ):
-        super(LocalStore, self).__init__(
+        super().__init__(
             config,
             storage_name,
             command_name,
@@ -1274,7 +1273,7 @@ class Scrape(CaomExecute):
         observable,
         meta_visitors,
     ):
-        super(Scrape, self).__init__(
+        super().__init__(
             config,
             mc.TaskType.SCRAPE,
             storage_name,
@@ -1324,7 +1323,7 @@ class ScrapeUpdate(CaomExecute):
         observable,
         meta_visitors,
     ):
-        super(ScrapeUpdate, self).__init__(
+        super().__init__(
             config,
             mc.TaskType.SCRAPE,
             storage_name,
@@ -1356,7 +1355,7 @@ class ScrapeUpdate(CaomExecute):
         self.logger.debug(f'End execute')
 
 
-class OrganizeChooser(object):
+class OrganizeChooser:
     """Extend this class to provide a way to make collection-specific
     complex conditions available within the OrganizeExecute class."""
 
@@ -1370,7 +1369,7 @@ class OrganizeChooser(object):
         return False
 
 
-class OrganizeExecutes(object):
+class OrganizeExecutes:
     """How to turn on/off various task types in a CaomExecute pipeline."""
 
     def __init__(

--- a/caom2pipe/execute_composable.py
+++ b/caom2pipe/execute_composable.py
@@ -210,9 +210,6 @@ class CaomExecute:
         self.log_file_directory = None
         self.data_visitors = []
         self.supports_latest_client = config.features.supports_latest_client
-        self._delete_cleanup_directory = (
-            mc.TaskType.SCRAPE not in config.task_types
-        )
         self._storage_inventory_resource_id = \
             config.storage_inventory_resource_id
         self._header_reader_client = header_reader_client
@@ -227,25 +224,6 @@ class CaomExecute:
             f'       lineage: {self._storage_name.lineage}\n'
             f'   working_dir: {self.working_dir}\n'
         )
-
-    def _cleanup(self):
-        """Remove a directory and all its contents. Only do this if there
-        is not a 'SCRAPE' task type, since the point of scraping is to
-        be able to look at the pipeline execution artefacts once the
-        processing is done.
-        """
-        self.logger.debug(
-            f'Remove working directory {self.working_dir} and contents.'
-        )
-        if os.path.exists(self.working_dir) and self._delete_cleanup_directory:
-            for ii in os.listdir(self.working_dir):
-                os.remove(os.path.join(self.working_dir, ii))
-            os.rmdir(self.working_dir)
-
-    def _create_dir(self):
-        """Create the working area if it does not already exist."""
-        self.logger.debug(f'Create working directory {self.working_dir}')
-        mc.create_dir(self.working_dir)
 
     def _find_fits2caom2_plugin(self):
         """Find the code that is passed as the --plugin parameter to
@@ -454,9 +432,6 @@ class MetaCreate(CaomExecute):
         self.logger.debug('Begin execute')
         self.logger.debug('the steps:')
 
-        self.logger.debug('create the work space, if it does not exist')
-        self._create_dir()
-
         self.logger.debug(
             'the observation does not exist, so go straight to generating '
             'the xml, as the main_app will retrieve the headers'
@@ -474,9 +449,6 @@ class MetaCreate(CaomExecute):
 
         self.logger.debug('create the observation with xml')
         self._repo_cmd_create_client(observation)
-
-        self.logger.debug('clean up the workspace')
-        self._cleanup()
 
         self.logger.debug('End execute')
 
@@ -519,9 +491,6 @@ class MetaUpdate(CaomExecute):
         self.logger.debug('Begin execute')
         self.logger.debug('the steps:')
 
-        self.logger.debug('create the work space, if it does not exist')
-        self._create_dir()
-
         self.logger.debug('write the observation to disk for next step')
         self._write_model(self.observation)
 
@@ -541,9 +510,6 @@ class MetaUpdate(CaomExecute):
 
         self.logger.debug('update the observation with xml')
         self._repo_cmd_update_client(self.observation)
-
-        self.logger.debug('clean up the workspace')
-        self._cleanup()
 
         self.logger.debug('End execute')
 
@@ -589,9 +555,6 @@ class MetaDeleteCreate(CaomExecute):
         self.logger.debug('Begin execute')
         self.logger.debug('the steps:')
 
-        self.logger.debug('create the work space, if it does not exist')
-        self._create_dir()
-
         self.logger.debug('write the observation to disk for next step')
         self._write_model(self.observation)
 
@@ -614,9 +577,6 @@ class MetaDeleteCreate(CaomExecute):
 
         self.logger.debug('store the xml')
         self._repo_cmd_create_client(self.observation)
-
-        self.logger.debug('clean up the workspace')
-        self._cleanup()
 
         self.logger.debug('End execute')
 
@@ -656,9 +616,6 @@ class LocalMetaCreate(CaomExecute):
     def execute(self, context):
         self.logger.debug('Begin execute')
 
-        self.logger.debug('create the work space, if it does not exist')
-        self._create_dir()
-
         self.logger.debug(
             'the observation does not exist, so go straight to generating '
             'the xml, as the main_app will retrieve the headers'
@@ -676,9 +633,6 @@ class LocalMetaCreate(CaomExecute):
 
         self.logger.debug('store the xml')
         self._repo_cmd_create_client(observation)
-
-        self.logger.debug('clean up the workspace')
-        self._cleanup()
 
         self.logger.debug('End execute')
 
@@ -722,9 +676,6 @@ class LocalMetaDeleteCreate(CaomExecute):
     def execute(self, context):
         self.logger.debug('Begin execute')
 
-        self.logger.debug('create the work space, if it does not exist')
-        self._create_dir()
-
         self.logger.debug('write the observation to disk for fits2caom2 step')
         self._write_model(self.observation)
 
@@ -747,9 +698,6 @@ class LocalMetaDeleteCreate(CaomExecute):
 
         self.logger.debug('store the xml')
         self._repo_cmd_create_client(observation)
-
-        self.logger.debug('clean up the workspace')
-        self._cleanup()
 
         self.logger.debug('End execute')
 
@@ -791,9 +739,6 @@ class LocalMetaUpdate(CaomExecute):
     def execute(self, context):
         self.logger.debug('Begin execute')
 
-        self.logger.debug('create the work space, if it does not exist')
-        self._create_dir()
-
         self.logger.debug('write the observation to disk for fits2caom2')
         self._write_model(self.observation)
 
@@ -813,9 +758,6 @@ class LocalMetaUpdate(CaomExecute):
 
         self.logger.debug('store the xml')
         self._repo_cmd_update_client(self.observation)
-
-        self.logger.debug('clean up the workspace')
-        self._cleanup()
 
         self.logger.debug('End execute')
 
@@ -859,9 +801,6 @@ class MetaVisit(CaomExecute):
         self.logger.debug('Begin execute')
         self.logger.debug('the steps:')
 
-        self.logger.debug('create the work space, if it does not exist')
-        self._create_dir()
-
         self.logger.debug('retrieve the existing observation, if it exists')
         observation = self._repo_cmd_read_client()
 
@@ -873,9 +812,6 @@ class MetaVisit(CaomExecute):
 
         self.logger.debug('store the xml')
         self._repo_cmd_update_client(observation)
-
-        self.logger.debug('clean up the workspace')
-        self._cleanup()
 
         self.logger.debug('End execute')
 
@@ -920,9 +856,6 @@ class DataVisit(CaomExecute):
     def execute(self, context):
         self._logger.debug('Begin execute')
 
-        self.logger.debug('create the work space, if it does not exist')
-        self._create_dir()
-
         self.logger.debug('get the input files')
         for entry in self._storage_name.destination_uris:
             local_fqn = os.path.join(self.working_dir, os.path.basename(entry))
@@ -939,9 +872,6 @@ class DataVisit(CaomExecute):
 
         self.logger.debug('store the updated xml')
         self._repo_cmd_update_client(observation)
-
-        self.logger.debug('clean up the workspace')
-        self._cleanup()
 
         self._logger.debug('End execute.')
 
@@ -997,9 +927,6 @@ class LocalDataVisit(DataVisit):
     def execute(self, context):
         self._logger.debug(f'Begin execute')
 
-        self.logger.debug('create the work space, if it does not exist')
-        self._create_dir()
-
         self._logger.debug('get the observation for the existing model')
         observation = self._repo_cmd_read_client()
 
@@ -1011,9 +938,6 @@ class LocalDataVisit(DataVisit):
 
         self._logger.debug('store the updated xml')
         self._repo_cmd_update_client(observation)
-
-        self.logger.debug('clean up the workspace')
-        self._cleanup()
 
         self._logger.debug(f'End execute')
 
@@ -1044,9 +968,6 @@ class DataScrape(DataVisit):
     def execute(self, context):
         self.logger.debug('Begin execute')
 
-        self.logger.debug('create the work space, if it does not exist')
-        self._create_dir()
-
         self.logger.debug('get observation for the existing model from disk')
         observation = self._read_model()
 
@@ -1055,9 +976,6 @@ class DataScrape(DataVisit):
 
         self.logger.debug('output the updated xml')
         self._write_model(observation)
-
-        self.logger.debug('clean up the workspace')
-        self._cleanup()
 
         self.logger.debug('End execute')
 
@@ -1093,9 +1011,6 @@ class Store(CaomExecute):
     def execute(self, context):
         self.logger.debug('Begin execute')
 
-        self.logger.debug('create the work space, if it does not exist')
-        self._create_dir()
-
         self.logger.debug(
             f'Store {len(self._storage_name.source_names)} files to CADC.'
         )
@@ -1117,9 +1032,6 @@ class Store(CaomExecute):
             self._transferrer.post_store_check(
                 entry, self._storage_name.destination_uris[index]
             )
-
-        self.logger.debug('clean up the workspace')
-        self._cleanup()
 
         self.logger.debug('End execute')
 
@@ -1194,9 +1106,6 @@ class Scrape(CaomExecute):
     def execute(self, context):
         self.logger.debug(f'Begin execute')
 
-        self.logger.debug('create the work space, if it does not exist')
-        self._create_dir()
-
         self.logger.debug('generate the xml from the file on disk')
         self._fits2caom2_out_local_no_visit()
 
@@ -1208,9 +1117,6 @@ class Scrape(CaomExecute):
 
         self.logger.debug('write the updated xml to disk for debugging')
         self._write_model(observation)
-
-        self.logger.debug('clean up the workspace')
-        self._cleanup()
 
         self.logger.debug(f'End execute')
 
@@ -1346,6 +1252,30 @@ class OrganizeExecutes:
         self._log_h = None
         self._logger = logging.getLogger(self.__class__.__name__)
         self._logger.setLevel(config.logging_level)
+
+    def _clean_up_workspace(self, obs_id):
+        """Remove a directory and all its contents. Only do this if there
+        is not a 'SCRAPE' task type, since the point of scraping is to
+        be able to look at the pipeline execution artefacts once the
+        processing is done.
+        """
+        working_dir = os.path.join(self.config.working_directory, obs_id)
+        self._logger.debug(
+            f'Remove working directory {working_dir} and contents.'
+        )
+        if (
+            os.path.exists(working_dir)
+            and mc.TaskType.SCRAPE not in self.config.task_types
+        ):
+            for ii in os.listdir(working_dir):
+                os.remove(os.path.join(working_dir, ii))
+            os.rmdir(working_dir)
+
+    def _create_workspace(self, obs_id):
+        """Create the working area if it does not already exist."""
+        working_dir = os.path.join(self.config.working_directory, obs_id)
+        self._logger.debug(f'Create working directory {working_dir}')
+        mc.create_dir(working_dir)
 
     def set_log_files(self, config):
         self.todo_fqn = config.work_fqn
@@ -1838,28 +1768,33 @@ class OrganizeExecutes:
                     'Rejected',
                 )
                 # successful rejection of the execution case
-                return 0
-            executors = self.choose(storage_name)
-            for executor in executors:
-                self._logger.info(
-                    f'Step {executor.task_type} with '
-                    f'{executor.__class__.__name__} for {storage_name.obs_id}'
-                )
-                executor.execute(context=None)
-            if len(executors) > 0:
-                self.capture_success(
-                    storage_name.obs_id, storage_name.file_name, start_s
-                )
-                return 0
+                result = 0
             else:
-                self._logger.info(f'No executors for {storage_name}')
-                return -1  # cover the case where file name validation fails
+                executors = self.choose(storage_name)
+                self._create_workspace(storage_name.obs_id)
+                for executor in executors:
+                    self._logger.info(
+                        f'Step {executor.task_type} with '
+                        f'{executor.__class__.__name__} for '
+                        f'{storage_name.obs_id}'
+                    )
+                    executor.execute(context=None)
+                if len(executors) > 0:
+                    self.capture_success(
+                        storage_name.obs_id, storage_name.file_name, start_s
+                    )
+                    result = 0
+                else:
+                    self._logger.info(f'No executors for {storage_name}')
+                    result = -1  # cover case where file name validation fails
         except Exception as e:
             self.capture_failure(storage_name, e, traceback.format_exc())
             self._logger.warning(
                 f'Execution failed for {storage_name.obs_id} with {e}'
             )
             self._logger.debug(traceback.format_exc())
-            return -1
+            result = -1
         finally:
+            self._clean_up_workspace(storage_name.obs_id)
             self._unset_file_logging()
+        return result

--- a/caom2pipe/execute_composable.py
+++ b/caom2pipe/execute_composable.py
@@ -341,7 +341,14 @@ class CaomExecute:
         if os.path.exists(self.model_fqn):
             return mc.read_obs_from_file(self.model_fqn)
         else:
-            return None
+            # this is wrong and should not be here, because it assumes the
+            # wrong pre-conditions
+            from caom2 import SimpleObservation, Algorithm
+            return SimpleObservation(
+                collection='DAO',
+                observation_id=self._storage_name.obs_id,
+                algorithm=Algorithm('exposure'),
+            )
 
     def _visit_meta(self, observation):
         """Execute metadata-only visitors on an Observation in

--- a/caom2pipe/execute_composable.py
+++ b/caom2pipe/execute_composable.py
@@ -329,7 +329,10 @@ class MetaVisitDeleteCreate(CaomExecute):
         self.logger.debug('Begin execute')
         self.logger.debug('the steps:')
 
-        self.logger.debug('retrieve the existing observation')
+        self.logger.debug('retrieve the headers')
+        self._metadata_reader.get(self._storage_name)
+
+        self.logger.debug('retrieve the observation if it exists')
         self._caom2_read()
 
         self.logger.debug('write the observation to disk for next step')
@@ -381,7 +384,7 @@ class MetaVisit(CaomExecute):
         self.logger.debug('retrieve the headers')
         self._metadata_reader.get(self._storage_name)
 
-        self.logger.debug('retrieve the existing observation, if it exists')
+        self.logger.debug('retrieve the observation if it exists')
         self._caom2_read()
 
         self.logger.debug('the metadata visitors')

--- a/caom2pipe/execute_composable.py
+++ b/caom2pipe/execute_composable.py
@@ -194,7 +194,7 @@ class CaomExecute:
         self._metadata_reader = metadata_reader
         self._observation = None
         # track whether the caom2repo call will be a create or an update
-        self._update_needed = False
+        self._caom2_update_needed = False
 
     def __str__(self):
         return (
@@ -214,12 +214,14 @@ class CaomExecute:
             self._storage_name.obs_id,
             self.observable.metrics,
         )
-        self._update_needed = False if self._observation is None else True
+        self._caom2_update_needed = (
+            False if self._observation is None else True
+        )
 
     def _caom2_store(self):
         """Update an existing observation instance.  Assumes the obs_id
         values are set correctly."""
-        if self._update_needed:
+        if self._caom2_update_needed:
             clc.repo_update(
                 self.caom_repo_client,
                 self._observation,
@@ -234,7 +236,7 @@ class CaomExecute:
 
     def _caom2_delete_create(self):
         """Delete an observation instance based on an input parameter."""
-        if self._update_needed:
+        if self._caom2_update_needed:
             clc.repo_delete(
                 self.caom_repo_client,
                 self._observation.collection,
@@ -255,7 +257,9 @@ class CaomExecute:
         self._observation = None
         if os.path.exists(self.model_fqn):
             self._observation = mc.read_obs_from_file(self.model_fqn)
-        self._update_needed = False if self._observation is None else True
+        self._caom2_update_needed = (
+            False if self._observation is None else True
+        )
 
     def _visit_meta(self):
         """Execute metadata-only visitors on an Observation in

--- a/caom2pipe/execute_composable.py
+++ b/caom2pipe/execute_composable.py
@@ -983,9 +983,11 @@ class OrganizeExecutes:
                     if hasattr(entry, '_cadc_client'):
                         entry.cadc_client = self._cadc_client
         for task_type in self.task_types:
-            self._logger.debug(task_type)
             if task_type == mc.TaskType.SCRAPE:
                 if self.config.use_local_files:
+                    self._logger.debug(
+                        f'Choosing executor Scrape for {task_type}.'
+                    )
                     executors.append(
                         Scrape(
                             self.config,
@@ -1003,6 +1005,9 @@ class OrganizeExecutes:
                     )
             elif task_type == mc.TaskType.STORE:
                 if self.config.use_local_files:
+                    self._logger.debug(
+                        f'Choosing executor LocalStore for {task_type}.'
+                    )
                     executors.append(
                         LocalStore(
                             self.config,
@@ -1012,6 +1017,9 @@ class OrganizeExecutes:
                         )
                     )
                 else:
+                    self._logger.debug(
+                        f'Choosing executor Store for {task_type}.'
+                    )
                     executors.append(
                         Store(
                             self.config,
@@ -1023,6 +1031,10 @@ class OrganizeExecutes:
                     )
             elif task_type == mc.TaskType.INGEST:
                 if self.chooser is not None and self.chooser.needs_delete():
+                    self._logger.debug(
+                        f'Choosing executor MetaVisitDeleteCreate for '
+                        f'{task_type}.'
+                    )
                     executors.append(
                         MetaVisitDeleteCreate(
                             self.config,
@@ -1035,6 +1047,9 @@ class OrganizeExecutes:
                         )
                     )
                 else:
+                    self._logger.debug(
+                        f'Choosing executor MetaVisit for {task_type}.'
+                    )
                     executors.append(
                         MetaVisit(
                             self.config,
@@ -1042,8 +1057,8 @@ class OrganizeExecutes:
                             self._cadc_client,
                             self._caom_client,
                             self._meta_visitors,
-                            self._metadata_reader,
                             self.observable,
+                            self._metadata_reader,
                         )
                     )
             elif task_type == mc.TaskType.MODIFY:
@@ -1054,6 +1069,10 @@ class OrganizeExecutes:
                                 and len(executors) > 0
                                 and isinstance(executors[0], Scrape)
                         ):
+                            self._logger.debug(
+                                f'Choosing executor DataScrape for '
+                                f'{task_type}.'
+                            )
                             executors.append(
                                 DataScrape(
                                     self.config,
@@ -1063,6 +1082,10 @@ class OrganizeExecutes:
                                 )
                             )
                         else:
+                            self._logger.debug(
+                                f'Choosing executor LocalDataVisit for '
+                                f'{task_type}.'
+                            )
                             executors.append(
                                 LocalDataVisit(
                                     self.config,
@@ -1074,6 +1097,9 @@ class OrganizeExecutes:
                                 )
                             )
                     else:
+                        self._logger.debug(
+                            f'Choosing executor DataVisit for {task_type}.'
+                        )
                         executors.append(
                             DataVisit(
                                 self.config,
@@ -1091,6 +1117,9 @@ class OrganizeExecutes:
                         f'{storage_name.file_name}.'
                     )
             elif task_type == mc.TaskType.VISIT:
+                self._logger.debug(
+                    f'Choosing executor MetaVisit for {task_type}.'
+                )
                 executors.append(
                     MetaVisit(
                         self.config,
@@ -1131,8 +1160,7 @@ class OrganizeExecutes:
                 self._create_workspace(storage_name.obs_id)
                 for executor in executors:
                     self._logger.info(
-                        f'Step {executor.task_type} with '
-                        f'{executor.__class__.__name__} for '
+                        f'Task with {executor.__class__.__name__} for '
                         f'{storage_name.obs_id}'
                     )
                     executor.execute(context=None)
@@ -1152,6 +1180,7 @@ class OrganizeExecutes:
             self._logger.debug(traceback.format_exc())
             result = -1
         finally:
+            self._metadata_reader.reset()
             self._clean_up_workspace(storage_name.obs_id)
             self._unset_file_logging()
         return result

--- a/caom2pipe/manage_composable.py
+++ b/caom2pipe/manage_composable.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # ***********************************************************************
 # ******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 # *************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
@@ -173,7 +172,7 @@ class CadcException(Exception):
     pass
 
 
-class Features(object):
+class Features:
     """Boolean feature flag implementation."""
 
     def __init__(self):
@@ -246,7 +245,7 @@ class Features(object):
 
     def __str__(self):
         return ' '.join(
-            '{} {}'.format(ii, getattr(self, ii)) for ii in vars(self)
+            f'{ii} {getattr(self, ii)}' for ii in vars(self)
         )
 
 
@@ -263,7 +262,7 @@ class TaskType(Enum):
     INGEST_OBS = 'ingest_obs'
 
 
-class State(object):
+class State:
     """Persist information between pipeline invocations.
 
     Currently the State class persists the concept of a bookmark, which is the
@@ -322,7 +321,7 @@ class State(object):
             write_as_yaml(self.content, self.fqn)
 
 
-class Rejected(object):
+class Rejected:
     """Persist information between pipeline invocations about the observation
     IDs that will fail a particular TaskType.
     """
@@ -422,7 +421,7 @@ class Rejected(object):
         return result
 
 
-class Metrics(object):
+class Metrics:
     """
     A class to capture execution metrics.
     """
@@ -477,7 +476,7 @@ def minimize_on_keyword(x, candidate):
     return result
 
 
-class Observable(object):
+class Observable:
     """
     A class to contain all the classes that maintain information between
     pipeline execution instances.
@@ -496,7 +495,7 @@ class Observable(object):
         return self._metrics
 
 
-class Cache(object):
+class Cache:
     """Abstract-like class to store persistent information that originates
     from outside of a pipeline invocation.
     """
@@ -538,7 +537,7 @@ class Cache(object):
         write_as_yaml(self._cache, self._fqn)
 
 
-class CaomName(object):
+class CaomName:
     """The naming rules for making and decomposing CAOM URIs (i.e. Observation
     URIs, Plane URIs, and archive URIs, all isolated in one class. There are
     probably OMM assumptions built in, but those will slowly go away :)."""
@@ -605,7 +604,7 @@ class CaomName(object):
         return file_name
 
 
-class Config(object):
+class Config:
     """Configuration information that remains the same for all steps and all
     work in a pipeline execution."""
 
@@ -1321,7 +1320,7 @@ class Config(object):
     def count_retries(self):
         result = []
         if os.path.exists(self.retry_fqn):
-            with open(self.retry_fqn, 'r') as f:
+            with open(self.retry_fqn) as f:
                 result = f.readlines()
         return len(result)
 
@@ -1453,7 +1452,7 @@ class PreviewMeta:
     mime_type: str = 'image/jpeg'
 
 
-class PreviewVisitor(object):
+class PreviewVisitor:
     """
     Common code for creating thumbnails and previews. Must be extended with
     the code that does the actual generation of thumbnail and preview
@@ -1576,7 +1575,7 @@ class PreviewVisitor(object):
                 )
 
 
-class StorageName(object):
+class StorageName:
     """
     This class encapsulates:
     - naming rules for a collection, for example:
@@ -1841,7 +1840,7 @@ class StorageName(object):
         return '.jpg' in entry
 
 
-class Validator(object):
+class Validator:
     """
     Compares the state of CAOM entries at CADC with the state of the source
     of the data. Identifies files that are in CAOM entries that do not exist
@@ -2450,7 +2449,7 @@ def read_from_file(fqn):
     """
     if not os.path.exists(fqn):
         raise CadcException(f'Could not find {fqn}')
-    with open(fqn, 'r') as f:
+    with open(fqn) as f:
         return f.readlines()
 
 
@@ -3116,7 +3115,7 @@ class ValueRepairCache(Cache):
     VALUE_REPAIR = 'value_repair'
 
     def __init__(self):
-        super(ValueRepairCache, self).__init__()
+        super().__init__()
         self._value_repair = self.get_from(ValueRepairCache.VALUE_REPAIR)
         self._key = None
         self._values = None

--- a/caom2pipe/manage_composable.py
+++ b/caom2pipe/manage_composable.py
@@ -258,8 +258,6 @@ class TaskType(Enum):
     INGEST = 'ingest'  # create/update a CAOM instance from metadata only
     MODIFY = 'modify'  # data access observation visitors
     VISIT = 'visit'  # metadata access observation visitors
-    # update a CAOM instance using CAOM metadata as input and knowledge
-    INGEST_OBS = 'ingest_obs'
 
 
 class State:

--- a/caom2pipe/manage_composable.py
+++ b/caom2pipe/manage_composable.py
@@ -1488,7 +1488,12 @@ class PreviewVisitor:
         # keys are uris, values are lists, where the 0th entry is a file name,
         # and the 1th entry is the artifact type
         self._previews = {}
+        self._report = None
         self._logger.debug(self)
+
+    @property
+    def report(self):
+        return self._report
 
     def __str__(self):
         return (
@@ -1509,7 +1514,8 @@ class PreviewVisitor:
         self._logger.info(
             f'Completed preview augmentation for {observation.observation_id}.'
         )
-        return {'artifacts': count}
+        self._report = {'artifacts': count}
+        return observation
 
     def add_preview(
         self,

--- a/caom2pipe/name_builder_composable.py
+++ b/caom2pipe/name_builder_composable.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # ***********************************************************************
 # ******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 # *************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
@@ -82,7 +81,7 @@ __all__ = [
 ]
 
 
-class StorageNameBuilder(object):
+class StorageNameBuilder:
     """
     The mechanisms for translating a list of work into a collection-specific
     name (otherwise known as which class instantiates the extension of the
@@ -112,7 +111,7 @@ class StorageNameBuilder(object):
 
 class StorageNameInstanceBuilder(StorageNameBuilder):
     def __init__(self, collection):
-        super(StorageNameInstanceBuilder, self).__init__()
+        super().__init__()
         self._collection = collection
 
     def build(self, entry):
@@ -131,7 +130,7 @@ class EntryBuilder(StorageNameBuilder):
     """
 
     def __init__(self, storage_name):
-        super(EntryBuilder, self).__init__()
+        super().__init__()
         self._storage_name = storage_name
 
     def build(self, entry):
@@ -145,7 +144,7 @@ class ObsIDBuilder(StorageNameBuilder):
     """
 
     def __init__(self, storage_name):
-        super(ObsIDBuilder, self).__init__()
+        super().__init__()
         self._storage_name = storage_name
 
     def build(self, entry):
@@ -159,7 +158,7 @@ class GuessingBuilder(StorageNameBuilder):
     """
 
     def __init__(self, storage_name):
-        super(GuessingBuilder, self).__init__()
+        super().__init__()
         self._storage_name = storage_name
         self._logger = logging.getLogger(self.__class__.__name__)
 

--- a/caom2pipe/reader_composable.py
+++ b/caom2pipe/reader_composable.py
@@ -88,11 +88,13 @@ class MetadataReader:
         self._headers = {}  # astropy.io.fits.Headers
         self._file_info = {}  # cadcdata.FileInfo
 
-    def get_file_info(self, uri):
-        return self._file_info.get(uri)
+    @property
+    def file_info(self):
+        return self._file_info
 
-    def get_headers(self, uri):
-        return self._headers.get(uri)
+    @property
+    def headers(self):
+        return self._headers
 
     def set(self, storage_name):
         """Retrieves the Header and FileInfo information."""

--- a/caom2pipe/run_composable.py
+++ b/caom2pipe/run_composable.py
@@ -184,7 +184,10 @@ class TodoRunner:
         self._logger = logging.getLogger(self.__class__.__name__)
 
     def _build_todo_list(self):
-        self._logger.debug('Begin _build_todo_list.')
+        self._logger.debug(
+            f'Begin _build_todo_list with '
+            f'{self._data_source.__class__.__name__}.'
+        )
         self._todo_list = self._data_source.get_work()
         self._organizer.complete_record_count = len(self._todo_list)
         self._logger.info(
@@ -253,7 +256,8 @@ class TodoRunner:
     def _run_todo_list(self):
         self._logger.debug('Begin _run_todo_list.')
         result = 0
-        for entry in self._todo_list:
+        while len(self._todo_list) > 0:
+            entry = self._todo_list.popleft()
             result |= self._process_entry(entry)
         self._finish_run()
         self._logger.debug('End _run_todo_list.')

--- a/caom2pipe/run_composable.py
+++ b/caom2pipe/run_composable.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # ***********************************************************************
 # ******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 # *************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
@@ -102,7 +101,7 @@ __all__ = [
 ]
 
 
-class RunnerReport(object):
+class RunnerReport:
     """
     This class contains metrics for reporting on pipeline runs.
     """
@@ -165,7 +164,7 @@ class RunnerReport(object):
         return msg
 
 
-class TodoRunner(object):
+class TodoRunner:
     """
     This class brings together the mechanisms for identifying the
     lists of work to be done (DataSource extensions), and the mechanisms for
@@ -330,7 +329,7 @@ class StateRunner(TodoRunner):
         bookmark_name,
         max_ts=None,
     ):
-        super(StateRunner, self).__init__(
+        super().__init__(
             config, organizer, builder, data_source
         )
         self._bookmark_name = bookmark_name

--- a/caom2pipe/tests/collection2caom2.py
+++ b/caom2pipe/tests/collection2caom2.py
@@ -4,6 +4,6 @@
 from caom2utils import fits2caom2
 
 
-def to_caom2():
-    args = fits2caom2.get_gen_proc_arg_parser().parse_args()
+def to_caom2_with_client(ingore):
+    args = fits2caom2.get_no_visit_gen_proc_arg_parser().parse_args()
     assert args is not None, 'expect args'

--- a/caom2pipe/tests/test_astro_composable.py
+++ b/caom2pipe/tests/test_astro_composable.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # ***********************************************************************
 # ******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 # *************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
@@ -69,7 +68,7 @@
 
 import math
 
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 import test_conf as tc
 
 from astropy.io import fits

--- a/caom2pipe/tests/test_caom_composable.py
+++ b/caom2pipe/tests/test_caom_composable.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # ***********************************************************************
 # ******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 # *************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
@@ -77,7 +76,7 @@ from caom2 import ValueCoord2D
 from caom2pipe import caom_composable as cc
 from caom2pipe import manage_composable as mc
 
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 import test_conf as tc
 
 try:

--- a/caom2pipe/tests/test_client_composable.py
+++ b/caom2pipe/tests/test_client_composable.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # ***********************************************************************
 # ******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 # *************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************

--- a/caom2pipe/tests/test_conf.py
+++ b/caom2pipe/tests/test_conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # ***********************************************************************
 # ******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 # *************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
@@ -83,7 +82,7 @@ class TestStorageName(mc.StorageName):
     def __init__(
         self, obs_id=None, file_name=None, uri=None, entry=None
     ):
-        super(TestStorageName, self).__init__(
+        super().__init__(
             'test_obs_id',
             'TEST',
             '*',
@@ -101,7 +100,7 @@ class TestStorageName(mc.StorageName):
 
 class TestChooser(ec.OrganizeChooser):
     def __init(self):
-        super(TestChooser, self).__init__()
+        super().__init__()
 
     def needs_delete(self, observation):
         return True

--- a/caom2pipe/tests/test_data_source_composable.py
+++ b/caom2pipe/tests/test_data_source_composable.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # ***********************************************************************
 # ******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 # *************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
@@ -77,7 +76,7 @@ from astropy.table import Table
 from cadctap import CadcTapClient
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from cadcdata import FileInfo
 from caom2pipe import data_source_composable as dsc

--- a/caom2pipe/tests/test_execute_composable.py
+++ b/caom2pipe/tests/test_execute_composable.py
@@ -479,17 +479,23 @@ def test_organize_executes_client_visit(test_config):
 
 def test_do_one(test_config):
     test_config.task_types = []
-    test_organizer = ec.OrganizeExecutes(test_config, 'test2caom2', [], [])
+    test_reader = Mock(autospec=True)
+    test_organizer = ec.OrganizeExecutes(
+        test_config, 'test2caom2', [], [], metadata_reader=test_reader
+    )
     # no client
     test_result = test_organizer.do_one(tc.TestStorageName())
     assert test_result is not None
     assert test_result == -1
+    assert test_reader.reset.called, 'reset should be called'
+    assert test_reader.reset.call_count == 1, 'wrong call count first time'
 
     # client
     test_config.features.use_clients = True
     test_result = test_organizer.do_one(tc.TestStorageName())
     assert test_result is not None
     assert test_result == -1
+    assert test_reader.reset.call_count == 2, 'wrong call count second time'
 
 
 def test_storage_name():

--- a/caom2pipe/tests/test_execute_composable.py
+++ b/caom2pipe/tests/test_execute_composable.py
@@ -681,7 +681,6 @@ def test_organize_executes_client_do_one(test_config):
     test_config.task_types = [mc.TaskType.INGEST]
     test_config.use_local_files = False
     test_chooser = tc.TestChooser()
-    ec.CaomExecute.repo_cmd_get_client = Mock(return_value=_read_obs(None))
     test_oe = ec.OrganizeExecutes(
         test_config,
         [],

--- a/caom2pipe/tests/test_execute_composable.py
+++ b/caom2pipe/tests/test_execute_composable.py
@@ -147,10 +147,13 @@ def test_meta_create_client_execute(test_config):
         header_reader_client=Mock(autospec=True),
     )
     try:
+        if not os.path.exists(test_executor.working_dir):
+            os.mkdir(test_executor.working_dir)
         test_executor.execute(None)
         assert repo_client_mock.create.called, 'create call missed'
         assert test_observer.metrics.observe.called, 'observe not called'
     finally:
+        _clean_up_dir(test_executor.working_dir)
         mc.read_obs_from_file = read_obs_orig
 
 
@@ -208,9 +211,14 @@ def test_meta_update_client_execute(test_config):
         observable=test_observer,
         header_reader_client=Mock(autospec=True),
     )
-    test_executor.execute(None)
-    assert repo_client_mock.update.called, 'update call missed'
-    assert test_observer.metrics.observe.called, 'observer call missed'
+    try:
+        if not os.path.exists(test_executor.working_dir):
+            os.mkdir(test_executor.working_dir)
+        test_executor.execute(None)
+        assert repo_client_mock.update.called, 'update call missed'
+        assert test_observer.metrics.observe.called, 'observer call missed'
+    finally:
+        _clean_up_dir(test_executor.working_dir)
 
 
 def test_meta_delete_create_client_execute(test_config):
@@ -231,10 +239,15 @@ def test_meta_delete_create_client_execute(test_config):
         observable=test_observer,
         header_reader_client=Mock(autospec=True),
     )
-    test_executor.execute(None)
-    assert repo_client_mock.delete.called, 'delete call missed'
-    assert repo_client_mock.create.called, 'create call missed'
-    assert test_observer.metrics.observe.called, 'observe not called'
+    try:
+        if not os.path.exists(test_executor.working_dir):
+            os.mkdir(test_executor.working_dir)
+        test_executor.execute(None)
+        assert repo_client_mock.delete.called, 'delete call missed'
+        assert repo_client_mock.create.called, 'create call missed'
+        assert test_observer.metrics.observe.called, 'observe not called'
+    finally:
+        _clean_up_dir(test_executor.working_dir)
 
 
 def test_local_meta_create_client_execute(test_config):
@@ -262,9 +275,14 @@ def test_local_meta_create_client_execute(test_config):
         observable=test_observer,
         header_reader_client=Mock(autospec=True),
     )
-    test_executor.execute(None)
-    assert repo_client_mock.create.called, 'create call missed'
-    assert test_observer.metrics.observe.called, 'observe not called'
+    try:
+        if not os.path.exists(test_executor.working_dir):
+            os.mkdir(test_executor.working_dir)
+        test_executor.execute(None)
+        assert repo_client_mock.create.called, 'create call missed'
+        assert test_observer.metrics.observe.called, 'observe not called'
+    finally:
+        _clean_up_dir(test_executor.working_dir)
 
 
 def test_local_meta_update_client_execute(test_config):
@@ -285,9 +303,14 @@ def test_local_meta_update_client_execute(test_config):
         observable=test_observer,
         header_reader_client=Mock(autospec=True),
     )
-    test_executor.execute(None)
-    assert repo_client_mock.update.called, 'update call missed'
-    assert test_observer.metrics.observe.called, 'observe not called'
+    try:
+        if not os.path.exists(test_executor.working_dir):
+            os.mkdir(test_executor.working_dir)
+        test_executor.execute(None)
+        assert repo_client_mock.update.called, 'update call missed'
+        assert test_observer.metrics.observe.called, 'observe not called'
+    finally:
+        _clean_up_dir(test_executor.working_dir)
 
 
 def test_local_meta_delete_create_client_execute(test_config):
@@ -308,10 +331,15 @@ def test_local_meta_delete_create_client_execute(test_config):
         observable=test_observer,
         header_reader_client=Mock(autospec=True),
     )
-    test_executor.execute(None)
-    assert repo_client_mock.delete.called, 'delete call missed'
-    assert repo_client_mock.create.called, 'create call missed'
-    assert test_observer.metrics.observe.called, 'observe not called'
+    try:
+        if not os.path.exists(test_executor.working_dir):
+            os.mkdir(test_executor.working_dir)
+        test_executor.execute(None)
+        assert repo_client_mock.delete.called, 'delete call missed'
+        assert repo_client_mock.create.called, 'create call missed'
+        assert test_observer.metrics.observe.called, 'observe not called'
+    finally:
+        _clean_up_dir(test_executor.working_dir)
 
 
 def test_client_visit(test_config):
@@ -380,10 +408,7 @@ def test_data_execute(test_config):
         assert repo_client_mock.update.called, 'update call missed'
         assert test_observer.metrics.observe.called, 'observe not called'
     finally:
-        if os.path.exists(test_fits_fqn):
-            os.unlink(test_fits_fqn)
-        if os.path.exists(test_dir):
-            os.rmdir(test_dir)
+        _clean_up_dir(test_dir)
 
 
 def test_data_execute_v(test_config):
@@ -431,10 +456,7 @@ def test_data_execute_v(test_config):
             'cadc:TEST/test_file.fits.gz', test_fits_fqn, send_md5=True
         ), 'wrong call args'
     finally:
-        if os.path.exists(test_fits_fqn):
-            os.unlink(test_fits_fqn)
-        if os.path.exists(test_dir):
-            os.rmdir(test_dir)
+        _clean_up_dir(test_dir)
 
 
 def test_data_local_execute(test_config):
@@ -528,7 +550,12 @@ def test_scrape(test_config):
         meta_visitors=[],
         header_reader_client=Mock(autospec=True),
     )
-    test_executor.execute(None)
+    try:
+        if not os.path.exists(test_executor.working_dir):
+            os.mkdir(test_executor.working_dir)
+        test_executor.execute(None)
+    finally:
+        _clean_up_dir(test_executor.working_dir)
 
 
 @patch('caom2pipe.manage_composable.read_obs_from_file')
@@ -896,24 +923,29 @@ def test_data_visit(client_mock, test_config):
         test_observable,
         test_transferrer,
     )
-    test_subject.execute(None)
-    assert client_mock.get.called, 'should be called'
-    client_mock.get.assert_called_with(
-        f'{tc.THIS_DIR}/test_obs_id', test_sn.destination_uris[0]
-    ), 'wrong get call args'
-    test_repo_client.read.assert_called_with(
-        'OMM', 'test_obs_id'
-    ), 'wrong values'
-    assert test_repo_client.update.called, 'expect an execution'
-    # TODO - why is the log file directory NOT the working directory?
+    try:
+        if not os.path.exists(test_subject.working_dir):
+            os.mkdir(test_subject.working_dir)
+        test_subject.execute(None)
+        assert client_mock.get.called, 'should be called'
+        client_mock.get.assert_called_with(
+            f'{tc.THIS_DIR}/test_obs_id', test_sn.destination_uris[0]
+        ), 'wrong get call args'
+        test_repo_client.read.assert_called_with(
+            'OMM', 'test_obs_id'
+        ), 'wrong values'
+        assert test_repo_client.update.called, 'expect an execution'
+        # TODO - why is the log file directory NOT the working directory?
 
-    args, kwargs = dv_mock.visit.call_args
-    assert kwargs.get('working_directory') == f'{tc.THIS_DIR}/test_obs_id'
-    assert (
-        kwargs.get('storage_name') == test_sn
-    ), 'wrong storage name parameter'
-    assert kwargs.get('log_file_directory') == tc.TEST_DATA_DIR
-    assert kwargs.get('stream') == 'TEST'
+        args, kwargs = dv_mock.visit.call_args
+        assert kwargs.get('working_directory') == f'{tc.THIS_DIR}/test_obs_id'
+        assert (
+            kwargs.get('storage_name') == test_sn
+        ), 'wrong storage name parameter'
+        assert kwargs.get('log_file_directory') == tc.TEST_DATA_DIR
+        assert kwargs.get('stream') == 'TEST'
+    finally:
+        _clean_up_dir(test_subject.working_dir)
 
 
 def test_store(test_config):
@@ -944,13 +976,18 @@ def test_store(test_config):
         test_subject._storage_name.destination_uris[0]
         == 'cadc:TEST/test_file.fits.gz'
     ), 'wrong destination'
-    test_subject.execute(None)
-    assert test_data_client.put.called, 'data put not called'
-    test_data_client.put.assert_called_with(
-        '/usr/src/app/caom2pipe/caom2pipe/tests/data/test_obs_id',
-        'cadc:TEST/test_file.fits.gz',
-        'TEST',
-    ), 'wrong put call args'
+    try:
+        if not os.path.exists(test_subject.working_dir):
+            os.mkdir(test_subject.working_dir)
+        test_subject.execute(None)
+        assert test_data_client.put.called, 'data put not called'
+        test_data_client.put.assert_called_with(
+            '/usr/src/app/caom2pipe/caom2pipe/tests/data/test_obs_id',
+            'cadc:TEST/test_file.fits.gz',
+            'TEST',
+        ), 'wrong put call args'
+    finally:
+        _clean_up_dir(test_subject.working_dir)
 
 
 def test_local_store(test_config):
@@ -1110,6 +1147,8 @@ def test_data_visit_params():
             test_transferrer,
         )
         assert test_subject is not None, 'broken ctor'
+        if not os.path.exists(test_subject.working_dir):
+            os.mkdir(test_subject.working_dir)
         test_subject.execute(context=None)
         assert data_visitor.visit.called, 'expect visit call'
         data_visitor.visit.assert_called_with(
@@ -1124,11 +1163,8 @@ def test_data_visit_params():
         ), f'wrong visit params {storage_name.source_names}'
         data_visitor.visit.reset_mock()
     finally:
-        if os.path.exists(test_wd):
-            dir_listing = os.listdir(test_wd)
-            for f in dir_listing:
-                os.unlink(f)
-            os.rmdir(test_wd)
+        _clean_up_dir(test_subject.working_dir)
+        _clean_up_dir(test_wd)
 
 
 def _transfer_get_mock(entry, fqn):
@@ -1138,6 +1174,13 @@ def _transfer_get_mock(entry, fqn):
     ), 'wrong fqn'
     with open(fqn, 'w') as f:
         f.write('test content')
+
+
+def _clean_up_dir(fqn):
+    if os.path.exists(fqn):
+        for ii in os.listdir(fqn):
+            os.unlink(os.path.join(fqn, ii))
+        os.rmdir(fqn)
 
 
 def _communicate():

--- a/caom2pipe/tests/test_execute_composable.py
+++ b/caom2pipe/tests/test_execute_composable.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # ***********************************************************************
 # ******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 # *************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
@@ -739,7 +738,7 @@ def test_choose_exceptions(test_config):
 def test_storage_name_failure(test_config):
     class TestStorageNameFails(tc.TestStorageName):
         def __init__(self):
-            super(TestStorageNameFails, self).__init__()
+            super().__init__()
 
         def is_valid(self):
             return False
@@ -1041,7 +1040,7 @@ def test_local_store(test_config):
 
 class FlagStorageName(mc.StorageName):
     def __init__(self, file_name, source_names, destination_uris):
-        super(FlagStorageName, self).__init__(
+        super().__init__(
             fname_on_disk=file_name,
             obs_id='1000003f',
             collection='TEST',
@@ -1219,7 +1218,7 @@ def _read_obs(arg1):
     return SimpleObservation(
         collection='test_collection',
         observation_id='test_obs_id',
-        algorithm=Algorithm(str('exposure')),
+        algorithm=Algorithm('exposure'),
     )
 
 
@@ -1295,7 +1294,7 @@ def to_caom2():
         SimpleObservation(
             collection='test_collection',
             observation_id='test_obs_id',
-            algorithm=Algorithm(str('exposure')),
+            algorithm=Algorithm('exposure'),
         ),
         fqn,
     )
@@ -1305,6 +1304,6 @@ def _mock_get_file_info(file_id):
     return FileInfo(
         id=file_id,
         size=10290,
-        md5sum='{}'.format(md5('-37'.encode()).hexdigest()),
+        md5sum='{}'.format(md5(b'-37').hexdigest()),
         file_type='image/jpeg',
     )

--- a/caom2pipe/tests/test_manage_composable.py
+++ b/caom2pipe/tests/test_manage_composable.py
@@ -737,16 +737,16 @@ def test_visit():
 
     try:
         test_subject = TestVisitor(**kwargs)
-        test_result = test_subject.visit(obs)
+        test_observation = test_subject.visit(obs)
     except Exception as e:
         assert False, f'{str(e)}'
 
-    assert test_result is not None, f'expect a result'
+    assert test_observation is not None, f'expect a result'
 
     check_number = 1
     end_artifact_count = 3
     expected_call_count = 1
-    assert test_result['artifacts'] == check_number, 'artifact not added'
+    assert test_subject.report['artifacts'] == check_number, 'artifact not added'
     assert (
         len(obs.planes[test_product_id].artifacts) == end_artifact_count
     ), f'new artifacts'

--- a/caom2pipe/tests/test_manage_composable.py
+++ b/caom2pipe/tests/test_manage_composable.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # ***********************************************************************
 # ******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 # *************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
@@ -93,7 +92,7 @@ def test_read_write_obs_with_file():
         SimpleObservation(
             collection='test_collection',
             observation_id='test_obs_id',
-            algorithm=Algorithm(str('exposure')),
+            algorithm=Algorithm('exposure'),
         ),
         TEST_OBS_FILE,
     )
@@ -435,7 +434,7 @@ def test_state():
     test_subject.save_state('gemini_timestamp', test_result + timedelta(3))
     test_subject.save_state('neossat_context', test_context)
 
-    with open(TEST_STATE_FILE, 'r') as f:
+    with open(TEST_STATE_FILE) as f:
         text = f.readlines()
         compare = ''.join(ii for ii in text)
         assert '2019-07-23' not in compare, 'content not updated'
@@ -485,7 +484,7 @@ def test_increment_time():
 @patch('requests.get')
 def test_http_get(mock_req):
     # Response mock
-    class Object(object):
+    class Object:
         def __init__(self):
             self.headers = {
                 'Date': 'Thu, 25 Jul 2019 16:10:02 GMT',
@@ -502,7 +501,7 @@ def test_http_get(mock_req):
             pass
 
         def iter_content(self, chunk_size):
-            return ['aaa'.encode(), 'bbb'.encode()]
+            return [b'aaa', b'bbb']
 
         def __enter__(self):
             return self
@@ -561,7 +560,7 @@ def test_create_dir():
 
 class TestValidator(mc.Validator):
     def __init__(self, source_name, preview_suffix):
-        super(TestValidator, self).__init__(
+        super().__init__(
             source_name, preview_suffix=preview_suffix
         )
 
@@ -685,7 +684,7 @@ def test_query_tap(caps_mock, base_mock, test_config):
 def test_visit():
     class TestVisitor(mc.PreviewVisitor):
         def __init__(self, **kwargs):
-            super(TestVisitor, self).__init__(archive='VLASS', **kwargs)
+            super().__init__(archive='VLASS', **kwargs)
 
         def generate_plots(self, obs_id):
             fqn = f'{self._working_dir}/{self._storage_name.prev}'
@@ -702,7 +701,7 @@ def test_visit():
 
     class VisitStorageName(tc.TestStorageName):
         def __init__(self):
-            super(VisitStorageName, self).__init__()
+            super().__init__()
             self._source_names = [self.file_uri]
 
         @property

--- a/caom2pipe/tests/test_name_builder_composable.py
+++ b/caom2pipe/tests/test_name_builder_composable.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # ***********************************************************************
 # ******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 # *************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************

--- a/caom2pipe/tests/test_reader_composable.py
+++ b/caom2pipe/tests/test_reader_composable.py
@@ -74,7 +74,7 @@ import test_conf as tc
 
 
 def test_file_reader():
-    test_subject = reader_composable.FileReader()
+    test_subject = reader_composable.FileMetadataReader()
     test_fqn = f'{tc.TEST_FILES_DIR}/correct.fits'
     test_uri = 'cadc:TEST/correct.fits'
     test_storage_name = mc.StorageName(

--- a/caom2pipe/tests/test_reader_composable.py
+++ b/caom2pipe/tests/test_reader_composable.py
@@ -83,19 +83,21 @@ def test_file_reader():
         destination_uris=[test_uri],
     )
     test_subject.set(test_storage_name)
-    assert len(test_subject._headers) == 1, 'wrong headers'
-    assert len(test_subject._file_info) == 1, 'wrong file_info'
-    test_header_result = test_subject.get_headers(test_uri)
+    test_header_result = test_subject.headers
     assert test_header_result is not None, 'expect a header result'
-    assert len(test_header_result) == 6, 'wrong header count'
-    test_file_info_result = test_subject.get_file_info(test_uri)
-    assert test_file_info_result is not None, 'expect a result'
-    assert test_file_info_result.id == basename(test_fqn), 'wrong uri'
-    assert test_file_info_result.file_type == 'application/fits', 'wrong type'
-    assert test_file_info_result.size == 197442, 'wrong size'
+    assert len(test_header_result) == 1, 'wrong headers'
+    test_headers = test_header_result.pop(test_uri)
+    assert len(test_headers) == 6, 'wrong header count'
+    test_file_info_result = test_subject.file_info
+    assert len(test_file_info_result) == 1, 'wrong file_info'
+    test_file_info = test_file_info_result.pop(test_uri)
+    assert test_file_info is not None, 'expect a result'
+    assert test_file_info.id == basename(test_fqn), 'wrong uri'
+    assert test_file_info.file_type == 'application/fits', 'wrong type'
+    assert test_file_info.size == 197442, 'wrong size'
     assert (
-            test_file_info_result.md5sum == '053b0780633ebab084b19050c0a58620'
+            test_file_info.md5sum == '053b0780633ebab084b19050c0a58620'
     ), 'wrong md5sum'
     test_subject.reset()
-    assert len(test_subject._headers) == 0, 'should be no headers'
-    assert len(test_subject._file_info) == 0, 'should be no file_info'
+    assert len(test_subject.headers) == 0, 'should be no headers'
+    assert len(test_subject.file_info) == 0, 'should be no file_info'

--- a/caom2pipe/tests/test_reader_composable.py
+++ b/caom2pipe/tests/test_reader_composable.py
@@ -82,15 +82,20 @@ def test_file_reader():
         source_names=[test_fqn],
         destination_uris=[test_uri],
     )
-    test_subject.get(test_storage_name)
-    assert len(test_subject.metadata) == 1, 'wrong metadata'
-    test_result = test_subject.metadata.get(test_uri)
-    assert test_result is not None, 'expect a result'
-    assert test_result.file_info.id == basename(test_fqn), 'wrong uri'
-    assert test_result.file_info.file_type == 'application/fits', 'wrong type'
-    assert test_result.file_info.size == 197442, 'wrong size'
+    test_subject.set(test_storage_name)
+    assert len(test_subject._headers) == 1, 'wrong headers'
+    assert len(test_subject._file_info) == 1, 'wrong file_info'
+    test_header_result = test_subject.get_headers(test_uri)
+    assert test_header_result is not None, 'expect a header result'
+    assert len(test_header_result) == 6, 'wrong header count'
+    test_file_info_result = test_subject.get_file_info(test_uri)
+    assert test_file_info_result is not None, 'expect a result'
+    assert test_file_info_result.id == basename(test_fqn), 'wrong uri'
+    assert test_file_info_result.file_type == 'application/fits', 'wrong type'
+    assert test_file_info_result.size == 197442, 'wrong size'
     assert (
-        test_result.file_info.md5sum == '053b0780633ebab084b19050c0a58620'
+            test_file_info_result.md5sum == '053b0780633ebab084b19050c0a58620'
     ), 'wrong md5sum'
     test_subject.reset()
-    assert len(test_subject.metadata) == 0, 'should be no metadata'
+    assert len(test_subject._headers) == 0, 'should be no headers'
+    assert len(test_subject._file_info) == 0, 'should be no file_info'

--- a/caom2pipe/tests/test_run_composable.py
+++ b/caom2pipe/tests/test_run_composable.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # ***********************************************************************
 # ******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 # *************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
@@ -76,7 +75,7 @@ import os
 from astropy.table import Table
 from datetime import datetime, timedelta, timezone
 
-from mock import Mock, patch, ANY
+from unittest.mock import Mock, patch, ANY
 import test_conf as tc
 
 from caom2 import SimpleObservation, Algorithm
@@ -239,7 +238,7 @@ def test_run_todo_file_data_source(clients_mock, test_config):
         SimpleObservation(
             collection=test_config.collection,
             observation_id='def',
-            algorithm=Algorithm(str('test')),
+            algorithm=Algorithm('test'),
         )
     )
 
@@ -273,7 +272,7 @@ def test_run_todo_file_data_source_v(clients_mock, test_config):
         return_value=SimpleObservation(
             collection=test_config.collection,
             observation_id='def',
-            algorithm=Algorithm(str('test')),
+            algorithm=Algorithm('test'),
         )
     )
 
@@ -412,7 +411,7 @@ def test_run_state_log_to_file_true(
             return_value=SimpleObservation(
                 collection=test_config.collection,
                 observation_id='def',
-                algorithm=Algorithm(str('test')),
+                algorithm=Algorithm('test'),
             )
         )
         fits2caom2_mock.side_effect = _mock_write
@@ -945,7 +944,7 @@ def _mock_write():
         SimpleObservation(
             collection='test_collection',
             observation_id='ghi',
-            algorithm=Algorithm(str('test')),
+            algorithm=Algorithm('test'),
         ),
         fqn,
     )
@@ -955,5 +954,5 @@ def _mock_read(ignore_fqn):
     return SimpleObservation(
         collection='test_collection',
         observation_id='ghi',
-        algorithm=Algorithm(str('test')),
+        algorithm=Algorithm('test'),
     )

--- a/caom2pipe/tests/test_run_composable.py
+++ b/caom2pipe/tests/test_run_composable.py
@@ -95,8 +95,8 @@ TEST_SOURCE = (
 )
 
 
-@patch('caom2pipe.execute_composable.CaomExecute._fits2caom2_cmd_local')
-@patch('caom2pipe.execute_composable.CaomExecute._fits2caom2_cmd_in_out_local')
+@patch('caom2pipe.execute_composable.CaomExecute._fits2caom2_out_local_no_visit')
+@patch('caom2pipe.execute_composable.CaomExecute._fits2caom2_in_out_local_no_visit')
 @patch('caom2pipe.manage_composable.read_obs_from_file')
 @patch('caom2pipe.manage_composable.write_obs_to_file')
 def test_run_todo_list_dir_data_source(
@@ -120,15 +120,15 @@ def test_run_todo_list_dir_data_source(
     assert test_result is not None, 'expect a result'
     assert test_result == 0, 'expect success'
     if fits2caom2_mock.called:
-        fits2caom2_mock.assert_called_with(connected=False)
+        fits2caom2_mock.assert_called_with()
     else:
         assert fits2caom2_in_out_mock.called, 'expect fits2caom2 in/out call'
     assert write_obs_mock.called, 'expect write call'
 
 
 @patch('caom2pipe.client_composable.ClientCollection', autospec=True)
-@patch('caom2pipe.execute_composable.CaomExecute._fits2caom2_cmd_local')
-@patch('caom2pipe.execute_composable.CaomExecute._fits2caom2_cmd_in_out_local')
+@patch('caom2pipe.execute_composable.CaomExecute._fits2caom2_out_local_no_visit')
+@patch('caom2pipe.execute_composable.CaomExecute._fits2caom2_in_out_local_no_visit')
 @patch('caom2pipe.manage_composable.read_obs_from_file')
 @patch('caom2pipe.manage_composable.write_obs_to_file')
 def test_run_todo_list_dir_data_source_v(
@@ -150,7 +150,7 @@ def test_run_todo_list_dir_data_source_v(
     assert test_result is not None, 'expect a result'
     assert test_result == 0, 'expect success'
     if fits2caom2_mock.called:
-        fits2caom2_mock.assert_called_with(connected=False)
+        fits2caom2_mock.assert_called_with()
     else:
         assert fits2caom2_in_out_mock.called, 'expect fits2caom2 in/out call'
     assert read_obs_mock.called, 'read_obs not called'
@@ -307,10 +307,10 @@ def test_run_todo_file_data_source_v(clients_mock, test_config):
 @patch('caom2pipe.data_source_composable.CadcTapClient')
 @patch('caom2pipe.client_composable.query_tap_client')
 @patch(
-    'caom2pipe.execute_composable.CaomExecute._fits2caom2_cmd_in_out',
+    'caom2pipe.execute_composable.CaomExecute._fits2caom2_in_out_no_visit',
     autospec=True,
 )
-@patch('caom2pipe.execute_composable.CaomExecute._fits2caom2_cmd')
+@patch('caom2pipe.execute_composable.CaomExecute._fits2caom2_out_no_visit')
 def test_run_state(
     fits2caom2_mock,
     fits2caom2_in_out_mock,
@@ -394,7 +394,7 @@ def test_run_state(
 @patch('caom2pipe.data_source_composable.CadcTapClient')
 @patch('caom2pipe.client_composable.ClientCollection', autospec=True)
 @patch('caom2pipe.client_composable.query_tap_client')
-@patch('caom2pipe.execute_composable.CaomExecute._fits2caom2_cmd')
+@patch('caom2pipe.execute_composable.CaomExecute._fits2caom2_out_no_visit')
 def test_run_state_log_to_file_true(
     fits2caom2_mock,
     tap_mock,

--- a/caom2pipe/tests/test_run_composable.py
+++ b/caom2pipe/tests/test_run_composable.py
@@ -95,15 +95,13 @@ TEST_SOURCE = (
 )
 
 
-@patch('caom2pipe.execute_composable.CaomExecute._fits2caom2_out_local_no_visit')
-@patch('caom2pipe.execute_composable.CaomExecute._fits2caom2_in_out_local_no_visit')
+@patch('caom2pipe.execute_composable.CaomExecute._visit_meta')
 @patch('caom2pipe.manage_composable.read_obs_from_file')
 @patch('caom2pipe.manage_composable.write_obs_to_file')
 def test_run_todo_list_dir_data_source(
     write_obs_mock,
     read_obs_mock,
-    fits2caom2_in_out_mock,
-    fits2caom2_mock,
+    visit_meta_mock,
     test_config,
 ):
     read_obs_mock.side_effect = _mock_read
@@ -115,27 +113,23 @@ def test_run_todo_list_dir_data_source(
 
     test_chooser = ec.OrganizeChooser()
     test_result = rc.run_by_todo(
-        config=test_config, chooser=test_chooser, command_name=TEST_COMMAND
+        config=test_config, chooser=test_chooser
     )
     assert test_result is not None, 'expect a result'
     assert test_result == 0, 'expect success'
-    if fits2caom2_mock.called:
-        fits2caom2_mock.assert_called_with()
-    else:
-        assert fits2caom2_in_out_mock.called, 'expect fits2caom2 in/out call'
+    assert visit_meta_mock.called, 'expect visit call'
+    visit_meta_mock.assert_called_with()
     assert write_obs_mock.called, 'expect write call'
 
 
 @patch('caom2pipe.client_composable.ClientCollection', autospec=True)
-@patch('caom2pipe.execute_composable.CaomExecute._fits2caom2_out_local_no_visit')
-@patch('caom2pipe.execute_composable.CaomExecute._fits2caom2_in_out_local_no_visit')
+@patch('caom2pipe.execute_composable.CaomExecute._visit_meta')
 @patch('caom2pipe.manage_composable.read_obs_from_file')
 @patch('caom2pipe.manage_composable.write_obs_to_file')
 def test_run_todo_list_dir_data_source_v(
     write_obs_mock,
     read_obs_mock,
-    fits2caom2_in_out_mock,
-    fits2caom2_mock,
+    visit_meta_mock,
     clients_mock,
     test_config,
 ):
@@ -146,13 +140,11 @@ def test_run_todo_list_dir_data_source_v(
     test_config.data_source_extensions = ['.fits']
     test_config.task_types = [mc.TaskType.SCRAPE]
     test_config.features.supports_latest_client = True
-    test_result = rc.run_by_todo(config=test_config, command_name=TEST_COMMAND)
+    test_result = rc.run_by_todo(config=test_config)
     assert test_result is not None, 'expect a result'
     assert test_result == 0, 'expect success'
-    if fits2caom2_mock.called:
-        fits2caom2_mock.assert_called_with()
-    else:
-        assert fits2caom2_in_out_mock.called, 'expect fits2caom2 in/out call'
+    assert visit_meta_mock.called, 'expect visit call'
+    visit_meta_mock.assert_called_with()
     assert read_obs_mock.called, 'read_obs not called'
     assert write_obs_mock.called, 'write_obs mock not called'
     assert not (
@@ -211,7 +203,6 @@ def test_run_todo_list_dir_data_source_invalid_fname_v(
             config=test_config,
             chooser=test_chooser,
             name_builder=test_builder,
-            command_name=TEST_COMMAND,
         )
         assert test_result is not None, 'expect a result'
         assert test_result == -1, 'expect failure, because of file naming'
@@ -251,7 +242,7 @@ def test_run_todo_file_data_source(clients_mock, test_config):
 
     test_chooser = ec.OrganizeChooser()
     test_result = rc.run_by_todo(
-        config=test_config, chooser=test_chooser, command_name=TEST_COMMAND
+        config=test_config, chooser=test_chooser
     )
     assert test_result is not None, 'expect a result'
     assert test_result == 0, 'expect success'
@@ -285,7 +276,7 @@ def test_run_todo_file_data_source_v(clients_mock, test_config):
 
     test_chooser = ec.OrganizeChooser()
     test_result = rc.run_by_todo(
-        config=test_config, chooser=test_chooser, command_name=TEST_COMMAND
+        config=test_config, chooser=test_chooser
     )
     assert test_result is not None, 'expect a result'
     assert test_result == 0, 'expect success'
@@ -307,23 +298,18 @@ def test_run_todo_file_data_source_v(clients_mock, test_config):
 @patch('caom2pipe.data_source_composable.CadcTapClient')
 @patch('caom2pipe.client_composable.query_tap_client')
 @patch(
-    'caom2pipe.execute_composable.CaomExecute._fits2caom2_in_out_no_visit',
-    autospec=True,
+    'caom2pipe.execute_composable.MetaVisit._visit_meta'
 )
-@patch('caom2pipe.execute_composable.CaomExecute._fits2caom2_out_no_visit')
 def test_run_state(
-    fits2caom2_mock,
-    fits2caom2_in_out_mock,
+    visit_meta_mock,
     tap_query_mock,
     tap_mock,
     clients_mock,
     test_config,
 ):
     # tap_mock is used by the data_source_composable class
-    fits2caom2_mock.side_effect = _mock_write
-    clients_mock.return_value.metadata_client.read.side_effect = Mock(
-        return_value=None
-    )
+    visit_meta_mock.side_effect = _mock_visit
+    clients_mock.return_value.metadata_client.read.side_effect = _mock_read2
     tap_query_mock.side_effect = _mock_get_work
 
     test_end_time = datetime.fromtimestamp(1579740838, tz=timezone.utc)
@@ -349,16 +335,13 @@ def test_run_state(
     test_result = rc.run_by_state(
         config=test_config,
         chooser=test_chooser,
-        command_name=TEST_COMMAND,
         bookmark_name=TEST_BOOKMARK,
         end_time=test_end_time,
     )
     assert test_result is not None, 'expect a result'
     assert test_result == 0, 'expect success'
-    if fits2caom2_mock.called:
-        fits2caom2_mock.assert_called_once_with()
-    elif fits2caom2_in_out_mock.called:
-        fits2caom2_in_out_mock.assert_called_once_with(ANY)
+    assert visit_meta_mock.called, 'expect visit meta call'
+    visit_meta_mock.assert_called_once_with()
 
     test_state = mc.State(STATE_FILE)
     test_bookmark = test_state.get_bookmark(TEST_BOOKMARK)
@@ -374,29 +357,24 @@ def test_run_state(
     # test that runner does nothing when times haven't changed
     start_time = test_end_time
     _write_state(start_time)
-    fits2caom2_mock.reset_mock()
-    fits2caom2_in_out_mock.reset_mock()
+    visit_meta_mock.reset_mock()
     test_result = rc.run_by_state(
         config=test_config,
         chooser=test_chooser,
-        command_name=TEST_COMMAND,
         bookmark_name=TEST_BOOKMARK,
         end_time=test_end_time,
     )
     assert test_result is not None, 'expect a result'
     assert test_result == 0, 'expect success'
-    assert not fits2caom2_mock.called, 'expect no fits2caom2 call'
-    assert (
-        not fits2caom2_in_out_mock.called
-    ), 'expect no update fits2caom2 call'
+    assert not visit_meta_mock.called, 'expect no visit_meta call'
 
 
 @patch('caom2pipe.data_source_composable.CadcTapClient')
 @patch('caom2pipe.client_composable.ClientCollection', autospec=True)
 @patch('caom2pipe.client_composable.query_tap_client')
-@patch('caom2pipe.execute_composable.CaomExecute._fits2caom2_out_no_visit')
+@patch('caom2pipe.execute_composable.CaomExecute._visit_meta')
 def test_run_state_log_to_file_true(
-    fits2caom2_mock,
+    visit_meta_mock,
     tap_mock,
     clients_mock,
     tap_mock2,
@@ -414,7 +392,7 @@ def test_run_state_log_to_file_true(
                 algorithm=Algorithm('test'),
             )
         )
-        fits2caom2_mock.side_effect = _mock_write
+        visit_meta_mock.side_effect = _mock_visit
         tap_mock.side_effect = _mock_get_work
 
         test_end_time = datetime.fromtimestamp(1579740838)
@@ -443,7 +421,6 @@ def test_run_state_log_to_file_true(
         test_result = rc.run_by_state(
             config=test_config,
             chooser=test_chooser,
-            command_name='collection2caom2',
             bookmark_name=TEST_BOOKMARK,
             end_time=test_end_time,
         )
@@ -483,7 +460,6 @@ def test_run_todo_list_dir_data_source_exception(
         test_result = rc.run_by_todo(
             config=test_config,
             chooser=test_chooser,
-            command_name=TEST_COMMAND,
             source=test_data_source,
         )
         assert test_result is not None, 'expect a result'
@@ -527,7 +503,7 @@ def test_run_todo_retry(do_one_mock, clients_mock, test_config):
     test_config.retry_failures = True
     _write_todo(test_config)
 
-    test_result = rc.run_by_todo(config=test_config, command_name=TEST_COMMAND)
+    test_result = rc.run_by_todo(config=test_config)
 
     assert test_result is not None, 'expect a result'
     assert test_result == -1, 'expect failure'
@@ -613,7 +589,6 @@ def test_run_single(do_mock, get_access_mock, test_config):
     test_result = rc.run_single(
         test_config,
         test_storage_name,
-        'test_command',
         meta_visitors=None,
         data_visitors=None,
     )
@@ -950,7 +925,19 @@ def _mock_write():
     )
 
 
+def _mock_read2(ign1, ign2):
+    return _mock_read(None)
+
+
 def _mock_read(ignore_fqn):
+    return SimpleObservation(
+        collection='test_collection',
+        observation_id='ghi',
+        algorithm=Algorithm('test'),
+    )
+
+
+def _mock_visit():
     return SimpleObservation(
         collection='test_collection',
         observation_id='ghi',

--- a/caom2pipe/tests/test_state.py
+++ b/caom2pipe/tests/test_state.py
@@ -73,7 +73,7 @@ import os
 from datetime import datetime, timedelta
 
 import dateutil.tz
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
 from cadcdata import FileInfo
 from caom2pipe import data_source_composable as dsc
@@ -127,6 +127,7 @@ class TestListDirTimeBoxDataSource(dsc.DataSource):
 def test_run_state(client_mock):
     client_mock.metadata_client.read.side_effect = tc.mock_read
     client_mock.data_client.get_file.side_effect = tc.mock_get_file
+    metadata_reader_mock = Mock(autospec=True)
 
     test_wd = '/usr/src/app/caom2pipe/int_test'
     caom2pipe_bookmark = 'caom2_timestamp'
@@ -185,7 +186,6 @@ def test_run_state(client_mock):
     try:
         test_result = rc.run_by_state(
             bookmark_name=caom2pipe_bookmark,
-            command_name='collection2caom2',
             config=test_config,
             end_time=test_end_time,
             name_builder=test_builder,
@@ -193,6 +193,7 @@ def test_run_state(client_mock):
             modify_transfer=transferrer,
             store_transfer=transferrer,
             clients=client_mock,
+            metadata_reader=metadata_reader_mock,
         )
 
         assert test_result is not None, 'expect a result'
@@ -265,7 +266,7 @@ def test_run_state_v(client_mock):
         size=42,
         md5sum='9473fdd0d880a43c21b7778d34872157',
     )
-
+    metadata_reader_mock = Mock(autospec=True)
     test_wd = '/usr/src/app/caom2pipe/int_test'
     caom2pipe_bookmark = 'caom2_timestamp'
     test_config = mc.Config()
@@ -323,7 +324,6 @@ def test_run_state_v(client_mock):
     try:
         test_result = rc.run_by_state(
             bookmark_name=caom2pipe_bookmark,
-            command_name='collection2caom2',
             config=test_config,
             end_time=test_end_time,
             name_builder=test_builder,
@@ -331,6 +331,7 @@ def test_run_state_v(client_mock):
             modify_transfer=transferrer,
             store_transfer=transferrer,
             clients=client_mock,
+            metadata_reader=metadata_reader_mock,
         )
 
         assert test_result is not None, 'expect a result'

--- a/caom2pipe/tests/test_state.py
+++ b/caom2pipe/tests/test_state.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # ***********************************************************************
 # ******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 # *************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
@@ -74,7 +73,7 @@ import os
 from datetime import datetime, timedelta
 
 import dateutil.tz
-from mock import patch
+from unittest.mock import patch
 
 from cadcdata import FileInfo
 from caom2pipe import data_source_composable as dsc
@@ -88,7 +87,7 @@ import test_conf as tc
 
 class TestTransfer(transfer_composable.Transfer):
     def __init__(self):
-        super(TestTransfer, self).__init__()
+        super().__init__()
 
     def get(self, source_fqn, dest_fqn):
         logging.error(f'source {source_fqn} dest {dest_fqn}')
@@ -110,7 +109,7 @@ class TestTransfer(transfer_composable.Transfer):
 
 class TestListDirTimeBoxDataSource(dsc.DataSource):
     def __init__(self):
-        super(TestListDirTimeBoxDataSource, self).__init__()
+        super().__init__()
 
     def get_time_box_work(self, prev_exec_time, exec_time):
         result = []
@@ -220,7 +219,7 @@ def test_run_state(client_mock):
         report_file = f'{test_config.log_file_directory}/app_report.txt'
         assert os.path.exists(report_file), f'report file {actual}'
         pass_through_test = False
-        with open(report_file, 'r') as f:
+        with open(report_file) as f:
             for line in f:
                 pass_through_test = True
                 if 'Number' in line:
@@ -363,7 +362,7 @@ def test_run_state_v(client_mock):
         report_file = f'{test_config.log_file_directory}/app_report.txt'
         assert os.path.exists(report_file), f'report file {actual}'
         pass_through_test = False
-        with open(report_file, 'r') as f:
+        with open(report_file) as f:
             for line in f:
                 pass_through_test = True
                 if 'Number' in line:

--- a/caom2pipe/tests/test_transfer_composable.py
+++ b/caom2pipe/tests/test_transfer_composable.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # ***********************************************************************
 # ******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 # *************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
@@ -70,7 +69,7 @@
 import os
 import pytest
 import shutil
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 
 from caom2pipe import manage_composable as mc
 from caom2pipe import transfer_composable as tc

--- a/caom2pipe/tests/test_translate_composable.py
+++ b/caom2pipe/tests/test_translate_composable.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # ***********************************************************************
 # ******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 # *************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
@@ -67,7 +66,7 @@
 # ***********************************************************************
 #
 
-from mock import patch
+from unittest.mock import patch
 
 from caom2utils import ObsBlueprint
 from caom2pipe import manage_composable as mc

--- a/caom2pipe/tests/test_visitor_composable.py
+++ b/caom2pipe/tests/test_visitor_composable.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # ***********************************************************************
 # ******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 # *************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************

--- a/caom2pipe/transfer_composable.py
+++ b/caom2pipe/transfer_composable.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # ***********************************************************************
 # ******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 # *************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
@@ -85,7 +84,7 @@ __all__ = [
 ]
 
 
-class Transfer(object):
+class Transfer:
     """
     No-op class to represent the actions of transferring a file from
     one point to another.
@@ -137,7 +136,7 @@ class CadcTransfer(Transfer):
     """
 
     def __init__(self):
-        super(CadcTransfer, self).__init__()
+        super().__init__()
         self._cadc_client = None
         self._logger = logging.getLogger(self.__class__.__name__)
 
@@ -171,7 +170,7 @@ class VoTransfer(Transfer):
     """
 
     def __init__(self):
-        super(VoTransfer, self).__init__()
+        super().__init__()
         self._cadc_client = None
         self._logger = logging.getLogger(self.__class__.__name__)
 
@@ -304,7 +303,7 @@ class VoFitsTransfer(FitsTransfer):
     """
 
     def __init__(self, vo_client):
-        super(VoFitsTransfer, self).__init__()
+        super().__init__()
         self._vo_client = vo_client
         self._logger = logging.getLogger(self.__class__.__name__)
 
@@ -322,7 +321,7 @@ class VoFitsCleanupTransfer(VoFitsTransfer):
     """
 
     def __init__(self, vo_client, config):
-        super(VoFitsCleanupTransfer, self).__init__(vo_client)
+        super().__init__(vo_client)
         self._cleanup_when_storing = config.cleanup_files_when_storing
         self._failure_destination = config.cleanup_failure_destination
         self._success_destination = config.cleanup_success_destination

--- a/caom2pipe/translate_composable.py
+++ b/caom2pipe/translate_composable.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # ***********************************************************************
 # ******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 # *************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************

--- a/caom2pipe/visitor_composable.py
+++ b/caom2pipe/visitor_composable.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # ***********************************************************************
 # ******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 # *************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
@@ -73,7 +72,7 @@ from caom2 import Observation
 from caom2pipe import manage_composable as mc
 
 
-class ArtifactCleanupVisitor(object):
+class ArtifactCleanupVisitor:
     """
     Common code for removing artifacts from an Observation. Over-ride
     'check_for_delete' method, if the characteristics of the deletion change.


### PR DESCRIPTION
There are several different CaomExecutes specializations that are not required if fits2caom2 executes as just another type of metadata visitation.