### PR TITLE
CADC-11789 - add support for fitsverify

### DIFF
--- a/caom2pipe/astro_composable.py
+++ b/caom2pipe/astro_composable.py
@@ -69,6 +69,7 @@
 import io
 import logging
 import requests
+import subprocess
 import traceback
 
 from astropy import units
@@ -101,6 +102,7 @@ __all__ = [
     'build_plane_time_sample',
     'build_ra_dec_as_deg',
     'check_fits',
+    'check_fitsverify',
     'convert_time',
     'FilterMetadataCache',
     'get_datetime',
@@ -161,6 +163,37 @@ def check_fits(fqn):
         return False
 
     return True
+
+
+def check_fitsverify(fqn):
+    """
+    Execute fitsverify on fqn
+    :return: bool True if compliant, False if Error count > 0
+    """
+    result = True
+    if '.fits' in fqn:
+        result = False
+        cmd = f'fitsverify -q {fqn}'
+        logging.debug(cmd)
+        cmd_array = cmd.split()
+        try:
+            output, outerr = subprocess.Popen(
+                cmd_array, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            ).communicate()
+            if (
+                output is not None
+                and len(output) > 0
+                and output[0] is not None
+                and ( 'and 0 errors' in output.decode('utf-8') or 'verification OK:' in output.decode('utf-8') )
+            ):
+                result = True
+            if not result:
+                logging.error(f'fitsverify failed with:\n{output.decode("utf-8")}{outerr.decode("utf-8")}')
+        except Exception as e:
+            logging.debug(f'Error with command {cmd}:: {e}')
+            logging.debug(traceback.format_exc())
+            raise mc.CadcException(f'Could not execute cmd {cmd}. Exception {e}')
+    return result
 
 
 def check_h5(fqn):

--- a/caom2pipe/data_source_composable.py
+++ b/caom2pipe/data_source_composable.py
@@ -480,7 +480,7 @@ class LocalFilesDataSource(ListDirTimeBoxDataSource):
             elif '.hdf5' in entry.name:
                 # no hdf5 validation
                 pass
-            elif ac.check_fits(entry.path):
+            elif ac.check_fitsverify(entry.path):
                 # only work with files that pass the FITS verification
                 if self._cleanup_when_storing:
                     if self._store_modified_files_only:

--- a/caom2pipe/manage_composable.py
+++ b/caom2pipe/manage_composable.py
@@ -3091,8 +3091,23 @@ def query_tap(query_string, proxy_fqn, resource_id, timeout=10):
     subject = net.Subject(certificate=proxy_fqn)
     tap_client = CadcTapClient(subject, resource_id=resource_id)
     buffer = io.StringIO()
-    tap_client.query(query_string, output_file=buffer, data_only=True, response_format='csv', timeout=timeout)
-    return Table.read(buffer.getvalue().split('\n'), format='csv')
+    tap_client.query(query_string, output_file=buffer, data_only=True, response_format='tsv', timeout=timeout)
+    return Table.read(buffer.getvalue().split('\n'), format='ascii.tab')
+
+
+def query_tap_pandas(query_string, client, timeout=10):
+    """
+    Return TAP query results as a Pandas Dataframe.
+
+    :param query_string: query to execute
+    :param client: CadcTapClient instance, pointed to a service that understands the query
+    :param timeout: in minutes
+
+    :return: Dataframe with query results
+    """
+    buffer = io.StringIO()
+    client.query(query_string, output_file=buffer, data_only=True, response_format='tsv', timeout=timeout)
+    return Table.read(buffer.getvalue().split('\n'), format='ascii.tab').to_pandas()
 
 
 def reverse_lookup(value_to_find, in_dict):

--- a/caom2pipe/run_composable.py
+++ b/caom2pipe/run_composable.py
@@ -665,6 +665,9 @@ def run_by_todo(
         clients=clients,
     )
 
+    source.capture_failure = organizer.capture_failure
+    source.capture_success = organizer.capture_success
+
     runner = TodoRunner(
         config, organizer, name_builder, source, metadata_reader, application
     )
@@ -749,6 +752,9 @@ def run_by_state(
         metadata_reader,
         clients,
     )
+
+    source.capture_failure = organizer.capture_failure
+    source.capture_success = organizer.capture_success
 
     runner = StateRunner(
         config,

--- a/caom2pipe/tests/test_astro_composable.py
+++ b/caom2pipe/tests/test_astro_composable.py
@@ -245,7 +245,7 @@ def test_check_h5():
     assert not test_result, 'missing failure'
 
 
-def test_check_fits_verify():
+def test_check_fitsverify():
     files = {
         '/test_files/a2020_06_17_07_00_01.fits': True,
         '/test_files/a2022_07_26_05_50_01.fits': False,
@@ -253,6 +253,7 @@ def test_check_fits_verify():
         '/test_files/scatsmth.flat.V.00.01.fits.gz': False,
         '/test_files/NEOS_SCI_2022223000524.fits': True,
         '/test_files/broken.fits': False,
+        '/test_files/dao_c122_2007_000882_v_1024.png': False,
     }
 
     for fqn, expected_result in files.items():
@@ -266,6 +267,7 @@ def test_check_fits_verify():
         '/test_files/scatsmth.flat.V.00.01.fits.gz': True,
         '/test_files/NEOS_SCI_2022223000524.fits': True,
         '/test_files/broken.fits': False,
+        '/test_files/dao_c122_2007_000882_v_1024.png': False,
     }
 
     for fqn, expected_result in files.items():

--- a/caom2pipe/tests/test_astro_composable.py
+++ b/caom2pipe/tests/test_astro_composable.py
@@ -243,3 +243,31 @@ def test_check_h5():
     test_fqn_missing = '/test_files/not_there.h5'
     test_result = ac.check_h5(test_fqn_missing)
     assert not test_result, 'missing failure'
+
+
+def test_check_fits_verify():
+    files = {
+        '/test_files/a2020_06_17_07_00_01.fits': True,
+        '/test_files/a2022_07_26_05_50_01.fits': False,
+        '/test_files/2377897o.fits.fz': True,
+        '/test_files/scatsmth.flat.V.00.01.fits.gz': False,
+        '/test_files/NEOS_SCI_2022223000524.fits': True,
+        '/test_files/broken.fits': False,
+    }
+
+    for fqn, expected_result in files.items():
+        test_result = ac.check_fitsverify(fqn)
+        assert test_result == expected_result, f'wrong fitsverify result {fqn}'
+
+    files = {
+        '/test_files/a2020_06_17_07_00_01.fits': True,
+        '/test_files/a2022_07_26_05_50_01.fits': True,
+        '/test_files/2377897o.fits.fz': True,
+        '/test_files/scatsmth.flat.V.00.01.fits.gz': True,
+        '/test_files/NEOS_SCI_2022223000524.fits': True,
+        '/test_files/broken.fits': False,
+    }
+
+    for fqn, expected_result in files.items():
+        test_result = ac.check_fits(fqn)
+        assert test_result == expected_result, f'wrong astropy verify result {fqn}'

--- a/caom2pipe/tests/test_data_source_composable.py
+++ b/caom2pipe/tests/test_data_source_composable.py
@@ -326,14 +326,14 @@ def test_list_dir_separate_data_source(test_config):
     assert test_subject is not None, 'ctor is broken'
     test_result = test_subject.get_work()
     assert test_result is not None, 'expect a result'
-    assert len(test_result) == 104, 'expect contents in the result'
+    assert len(test_result) == 67, 'expect contents in the result'
     assert '/test_files/sub_directory/abc.fits' in test_result, 'wrong entry'
 
     test_config.recurse_data_sources = False
     test_subject = dsc.ListDirSeparateDataSource(test_config)
     test_result = test_subject.get_work()
     assert test_result is not None, 'expect a non-recursive result'
-    assert len(test_result) == 100, 'expect contents in non-recursive result'
+    assert len(test_result) == 63, 'expect contents in non-recursive result'
     assert (
         '/test_files/sub_directory/abc.fits' not in test_result
     ), 'recursive result should not be present'

--- a/caom2pipe/tests/test_data_source_composable.py
+++ b/caom2pipe/tests/test_data_source_composable.py
@@ -326,14 +326,14 @@ def test_list_dir_separate_data_source(test_config):
     assert test_subject is not None, 'ctor is broken'
     test_result = test_subject.get_work()
     assert test_result is not None, 'expect a result'
-    assert len(test_result) == 100, 'expect contents in the result'
+    assert len(test_result) == 104, 'expect contents in the result'
     assert '/test_files/sub_directory/abc.fits' in test_result, 'wrong entry'
 
     test_config.recurse_data_sources = False
     test_subject = dsc.ListDirSeparateDataSource(test_config)
     test_result = test_subject.get_work()
     assert test_result is not None, 'expect a non-recursive result'
-    assert len(test_result) == 96, 'expect contents in non-recursive result'
+    assert len(test_result) == 100, 'expect contents in non-recursive result'
     assert (
         '/test_files/sub_directory/abc.fits' not in test_result
     ), 'recursive result should not be present'

--- a/caom2pipe/tests/test_manage_composable.py
+++ b/caom2pipe/tests/test_manage_composable.py
@@ -618,12 +618,12 @@ def test_validator2(caps_mock, ad_mock):
     response = Mock()
     response.status_code = 200
     response.iter_content.return_value = [
-        b'ingestDate,fileName\n'
-        b'2019-10-23T16:27:19.000,NEOS_SCI_2015347000000_clean.fits\n'
-        b'2019-10-23T16:27:27.000,NEOS_SCI_2015347000000.fits\n'
-        b'2019-10-23T16:27:33.000,NEOS_SCI_2015347002200_clean.fits\n'
-        b'2019-10-23T16:27:40.000,NEOS_SCI_2015347002200.fits\n'
-        b'2019-10-23T16:27:47.000,NEOS_SCI_2015347002500_clean.fits\n'
+        b'ingestDate\tfileName\n'
+        b'2019-10-23T16:27:19.000\tNEOS_SCI_2015347000000_clean.fits\n'
+        b'2019-10-23T16:27:27.000\tNEOS_SCI_2015347000000.fits\n'
+        b'2019-10-23T16:27:33.000\tNEOS_SCI_2015347002200_clean.fits\n'
+        b'2019-10-23T16:27:40.000\tNEOS_SCI_2015347002200.fits\n'
+        b'2019-10-23T16:27:47.000\tNEOS_SCI_2015347002500_clean.fits\n'
     ]
     ad_mock.return_value.__enter__.return_value = response
     getcwd_orig = os.getcwd

--- a/caom2pipe/tests/test_run_composable.py
+++ b/caom2pipe/tests/test_run_composable.py
@@ -66,7 +66,6 @@
 # ***********************************************************************
 #
 
-import distutils
 import logging
 import pytest
 import glob
@@ -95,9 +94,6 @@ STATE_FILE = os.path.join(tc.TEST_DATA_DIR, 'test_state.yml')
 TEST_BOOKMARK = 'test_bookmark'
 TEST_COMMAND = 'test_command'
 TEST_DIR = f'{tc.TEST_DATA_DIR}/run_composable'
-TEST_SOURCE = (
-    f'{distutils.sysconfig.get_python_lib()}/test_command/' f'test_command.py'
-)
 
 
 @patch('caom2pipe.execute_composable.CaomExecute._visit_meta')

--- a/caom2pipe/transfer_composable.py
+++ b/caom2pipe/transfer_composable.py
@@ -211,8 +211,8 @@ class ScienceTransfer(Transfer):
         result = True
         msg = ''
         if '.fits' in dest_fqn:
-            result = ac.check_fits(dest_fqn)
-            msg = f'astropy error when reading {dest_fqn}'
+            result = ac.check_fitsverify(dest_fqn)
+            msg = f'fitsverify error when reading {dest_fqn}'
         elif dest_fqn.endswith('.h5') or dest_fqn.endswith('.hdf5'):
             result = ac.check_h5(dest_fqn)
             msg = f'h5check error when reading {dest_fqn}'

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,9 +32,12 @@ author_email = cadc@nrc-cnrc.gc.ca
 license = AGPLv3
 url = http://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/caom2
 edit_on_github = False
-github_project = opencadc/caom2tools
+github_project = opencadc/caom2pipe
 install_requires = cadcdata caom2utils>=1.4.2 caom2repo vos cadctap
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
-version = 0.7.3
+version = 0.8
+
+[flake8]
+max-line-length = 120
 
 [entry_points]

--- a/setup.py
+++ b/setup.py
@@ -95,8 +95,5 @@ setup(name=PACKAGENAME,
         'Programming Language :: Python',
         'Programming Language :: Python :: 3.6'
       ],
-      cmdclass = {
-          'coverage': PyTest,
-          'inttest': IntTestCommand
-      }
+      cmdclass = {'coverage': PyTest}
 )

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,6 @@ from setuptools import find_packages
 
 from setuptools import setup
 
-import distutils.cmd
-import distutils.log
 import subprocess
 
 # read the README.md file and return as string.
@@ -73,25 +71,6 @@ class PyTest(TestCommand):
         err_no = pytest.main(self.pytest_args)
         sys.exit(err_no)
         
-class IntTestCommand(distutils.cmd.Command):
-  """A custom command to run integration tests."""
-
-  description = 'Integration tests'
-  user_options = []
-  
-  def initialize_options(self):
-    """Set default values for options."""
-    # Each user option must be listed here with their default value.
-
-  def finalize_options(self):
-    """Post-process options."""
-
-  def run(self):
-    """Run command."""
-    import pytest
-    testfile = os.getcwd() + '/tests/test_integration.py'
-    pytest.main(['-s', '--capture=no','-x', testfile])
-
 install_requires=metadata.get('install_requires', '').strip().split()
 
 setup(name=PACKAGENAME,


### PR DESCRIPTION
Use tabs instead of commands when reading TAP queries, as some OMM file names have commas.

Remove distutils dependencies for 3.10 compatibility.