### PR TITLE
CADC-12287 - replace time-box endpoint type timestamp with time-zone aware datetime

### DIFF
--- a/caom2pipe/data_source_composable.py
+++ b/caom2pipe/data_source_composable.py
@@ -73,7 +73,7 @@ import traceback
 
 from collections import deque, defaultdict
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 
 from cadctap import CadcTapClient
 from cadcutils import exceptions
@@ -113,10 +113,10 @@ class DataSource:
         deque of work todo as a method implementation
     """
 
-    def __init__(self, config=None):
+    def __init__(self, config=None, zone=timezone.utc):
         self._config = config
-        # if this value is used, it should be a timestamp - i.e. a float
-        self._start_time_ts = None
+        # if this value is used, it should be a timezone-aware datetime
+        self._start_dt = None
         self._extensions = None
         if config is not None:
             self._extensions = config.data_source_extensions
@@ -124,6 +124,7 @@ class DataSource:
         self._skipped_files = 0
         self._work = deque()
         self._reporter = None
+        self._timezone = zone
         self._logger = logging.getLogger(self.__class__.__name__)
 
     def _capture_todo(self):
@@ -148,10 +149,10 @@ class DataSource:
     def get_work(self):
         return deque()
 
-    def get_time_box_work(self, prev_exec_time, exec_time):
+    def get_time_box_work(self, prev_exec_dt, exec_dt):
         """
-        :param prev_exec_time: tz-aware datetime.timestamp
-        :param exec_time: tz-aware datetime.timestamp
+        :param prev_exec_dt: tz-aware datetime
+        :param exec_dt: tz-aware datetime
         """
         return deque()
 
@@ -164,12 +165,16 @@ class DataSource:
         self._reporter = value
 
     @property
-    def start_time_ts(self):
-        return self._start_time_ts
+    def start_dt(self):
+        return self._start_dt
 
-    @start_time_ts.setter
-    def start_time_ts(self, value):
-        self._start_time_ts = value
+    @start_dt.setter
+    def start_dt(self, value):
+        self._start_dt = value
+
+    @property
+    def timezone(self):
+        return self._timezone
 
 
 class ListDirDataSource(DataSource):

--- a/caom2pipe/data_source_composable.py
+++ b/caom2pipe/data_source_composable.py
@@ -292,55 +292,47 @@ class ListDirTimeBoxDataSource(DataSource):
         self._recursive = config.recurse_data_sources
         self._temp = defaultdict(list)
 
-    def get_time_box_work(self, prev_exec_time, exec_time):
+    def get_time_box_work(self, prev_exec_dt, exec_dt):
         """
-        :param prev_exec_time tz-aware datetime.timestamp start of the timestamp chunk
-        :param exec_time tz-aware datetime.timestamp end of the timestamp chunk
+        :param prev_exec_dt tz-aware datetime start of the time-boxed chunk
+        :param exec_dt tz-aware datetime end of the time-goxed chunk
         :return: a deque of StateRunnerMeta instances, with
             prev_exec_time <= os.stat.mtime <= exec_time, and sorted by
             os.stat.mtime
         """
         self._logger.debug(
-            f'Begin get_time_box_work from {prev_exec_time} to {exec_time}.'
+            f'Begin get_time_box_work from {prev_exec_dt} to {exec_dt}.'
         )
         for source in self._source_directories:
             self._logger.debug(f'Looking for work in {source}')
-            self._append_work(prev_exec_time, exec_time, source)
+            self._append_work(prev_exec_dt, exec_dt, source)
         # ensure the result returned is sorted by timestamp in ascending
         # order
         for mtime in sorted(self._temp):
             for entry in self._temp[mtime]:
-                self._work.append(
-                    StateRunnerMeta(entry_name=entry, entry_ts=mtime)
-                )
+                self._work.append(StateRunnerMeta(entry_name=entry, entry_dt=mtime))
         self._temp = defaultdict(list)
         self._capture_todo()
         self._logger.debug('End get_time_box_work')
         return self._work
 
-    def _append_work(self, prev_exec_time, exec_time, entry_path):
+    def _append_work(self, prev_exec_dt, exec_dt, entry_path):
         with os.scandir(entry_path) as dir_listing:
             for entry in dir_listing:
                 # the slowest thing to do is the 'stat' call, so delay it as
                 # long as possible, and only if necessary
                 if entry.is_dir() and self._recursive:
                     entry_stats = entry.stat()
-                    if exec_time >= entry_stats.st_mtime >= prev_exec_time:
-                        self._append_work(
-                            prev_exec_time, exec_time, entry.path
-                        )
+                    entry_st_mtime_dt = datetime.fromtimestamp(entry_stats.st_mtime, tz=self._timezone)
+                    if exec_dt >= entry_st_mtime_dt >= prev_exec_dt:
+                        self._append_work(prev_exec_dt, exec_dt, entry.path)
                 else:
                     # send the dir_listing value
                     if self.default_filter(entry):
                         entry_stats = entry.stat()
-                        if (
-                            exec_time
-                            >= entry_stats.st_mtime
-                            >= prev_exec_time
-                        ):
-                            self._temp[entry_stats.st_mtime].append(
-                                entry.path
-                            )
+                        entry_st_mtime_dt = datetime.fromtimestamp(entry_stats.st_mtime, tz=self._timezone)
+                        if exec_dt >= entry_st_mtime_dt >= prev_exec_dt:
+                            self._temp[entry_st_mtime_dt].append(entry.path)
 
 
 class LocalFilesDataSource(ListDirTimeBoxDataSource):
@@ -483,15 +475,14 @@ class LocalFilesDataSource(ListDirTimeBoxDataSource):
         self._capture_todo()
         return self._work
 
-    def _append_work(self, prev_exec_time, exec_time, entry_path):
+    def _append_work(self, prev_exec_dt, exec_dt, entry_path):
         with os.scandir(entry_path) as dir_listing:
             for entry in dir_listing:
                 if entry.is_dir() and self._recursive:
                     entry_stats = entry.stat()
-                    if exec_time >= entry_stats.st_mtime >= prev_exec_time:
-                        self._append_work(
-                            prev_exec_time, exec_time, entry.path
-                        )
+                    entry_st_mtime_dt = datetime.fromtimestamp(entry_stats.st_mtime, tz=self._timezone)
+                    if exec_dt >= entry_st_mtime_dt >= prev_exec_dt:
+                        self._append_work(prev_exec_dt, exec_dt, entry.path)
                 else:
                     # order the stats check before the default_filter check,
                     # because CFHT likes to work with tens of thousands of
@@ -505,11 +496,9 @@ class LocalFilesDataSource(ListDirTimeBoxDataSource):
                     if not entry.name.startswith('.'):
                         entry_stats = entry.stat()
                         entry_st_mtime_dt = datetime.fromtimestamp(entry_stats.st_mtime, tz=self._timezone)
-                        if exec_time >= entry_st_mtime_dt >= prev_exec_time:
+                        if exec_dt >= entry_st_mtime_dt >= prev_exec_dt:
                             if self.default_filter(entry):
-                                self._temp[entry_stats.st_mtime].append(
-                                    entry.path
-                                )
+                                self._temp[entry_st_mtime_dt].append(entry.path)
 
     def _is_remote_different(self, entry_path):
         """
@@ -631,8 +620,8 @@ def is_offset_aware(dt):
 class StateRunnerMeta:
     # how to refer to the item of work to be processed
     entry_name: str
-    # offset-aware timestamp associated with item of work
-    entry_ts: datetime.timestamp  # = field(default_factory=is_offset_aware)
+    # offset-aware datetime associated with item of work
+    entry_dt: datetime
 
 
 class QueryTimeBoxDataSource(DataSource):
@@ -683,7 +672,10 @@ class QueryTimeBoxDataSource(DataSource):
         self._work = deque()
         for row in rows:
             ignore_scheme, ignore_path, f_name = mc.decompose_uri(row['uri'])
-            self._work.append(StateRunnerMeta(f_name, row['lastModified']))
+            read_fmt = '%Y-%m-%dT%H:%M:%S.%f'
+            self._work.append(
+                StateRunnerMeta(f_name, datetime.strptime(row['lastModified'], read_fmt).astimezone(self._timezone))
+            )
         self._capture_todo()
         self._logger.debug(f'End get_time_box_work.')
         return self._work
@@ -713,10 +705,10 @@ class VaultDataSource(ListDirTimeBoxDataSource):
         self._logger.debug('End get_work.')
         return self._work
 
-    def _append_work(self, prev_exec_time, exec_time, entry):
+    def _append_work(self, prev_exec_dt, exec_dt, entry):
         """
-        :param prev_exec_time: datetime.timestamp
-        :param exec_time: datetime.timestamp
+        :param prev_exec_dt: datetime
+        :param exec_dt: datetime
         :param entry: Vault URI
         """
         self._logger.info(f'Begin _append_work in {entry}.')
@@ -728,14 +720,14 @@ class VaultDataSource(ListDirTimeBoxDataSource):
         for target in node.node_list:
             target_fqn = f'{node.uri}/{target}'
             target_node = self._vault_client.get_node(target_fqn)
-            target_node_mtime = mc.make_time_tz(target_node.props.get('date')).timestamp()
+            target_node_mtime = mc.make_time_tz(target_node.props.get('date'), self._timezone)
             if target_node.type == 'vos:ContainerNode' and self._recursive:
-                if exec_time >= target_node_mtime >= prev_exec_time:
+                if exec_dt >= target_node_mtime >= prev_exec_dt:
                     self._append_work(
-                        prev_exec_time, exec_time, target_node.uri
+                        prev_exec_dt, exec_dt, target_node.uri
                     )
             else:
-                if exec_time >= target_node_mtime >= prev_exec_time:
+                if exec_dt >= target_node_mtime >= prev_exec_dt:
                     if self.default_filter(target_node):
                         self._temp[target_node_mtime].append(target_node.uri)
                         self._logger.info(

--- a/caom2pipe/manage_composable.py
+++ b/caom2pipe/manage_composable.py
@@ -2933,7 +2933,7 @@ def make_time(from_str):
     return result
 
 
-def make_time_tz(from_value):
+def make_time_tz(from_value, zone=timezone.utc):
     """
     Make an offset-aware datetime value. Input parameters should be in
     datetime format, but a modest attempt is made to check for otherwise.
@@ -2944,6 +2944,7 @@ def make_time_tz(from_value):
     - make_seconds checks for time zones and adjusts there
 
     :param from_value a representation of time.
+    :param zone timezone
     :return the time as an offset-aware datetime
 
     from_value accepted types:
@@ -2957,16 +2958,16 @@ def make_time_tz(from_value):
     if isinstance(from_value, datetime):
         result = from_value
         if from_value.tzinfo is None:
-            result = from_value.replace(tzinfo=timezone.utc)
+            result = from_value.replace(tzinfo=zone)
     elif isinstance(from_value, str):
         temp = make_seconds(from_value)
         result = None
         if temp is not None:
-            result = datetime.fromtimestamp(temp, tz=timezone.utc)
+            result = datetime.fromtimestamp(temp, tz=zone)
     elif isinstance(from_value, float):
-        result = datetime.fromtimestamp(from_value, tz=timezone.utc)
+        result = datetime.fromtimestamp(from_value, tz=zone)
     else:
-        result = from_value.fromtimestamp(from_value, tz=timezone.utc)
+        result = from_value.fromtimestamp(from_value, tz=zone)
     return result
 
 

--- a/caom2pipe/run_composable.py
+++ b/caom2pipe/run_composable.py
@@ -301,11 +301,11 @@ class StateRunner(TodoRunner):
             os.makedirs(os.path.dirname(self._config.progress_fqn))
 
         state = mc.State(self._config.state_fqn)
-        if self._data_source.start_time is None:
+        if self._data_source.start_dt is None:
             temp = state.get_bookmark(self._bookmark_name)
             start_time = temp.astimezone(self._data_source.timezone)
         else:
-            start_time = self._data_source.start_time
+            start_time = self._data_source.start_dt
 
         # make sure prev_exec_time is offset-aware type datetime.timestamp
         prev_exec_time = start_time
@@ -420,7 +420,7 @@ def common_runner_init(
     use the defaults created here for the 'run' call, or they can provide their own specializations of the various
     classes required to store data and ingest metadata at CADC.
 
-    :param config Config instance
+    :param config: Config instance
     :param clients: ClientCollection instance
     :param name_builder NameBuilder extension that creates an instance of a StorageName extension, from an entry from
         a DataSourceComposable listing
@@ -435,6 +435,7 @@ def common_runner_init(
     :param meta_visitors list of modules with visit methods, that expect the metadata of a work file to exist on disk
     :param data_visitors list of modules with visit methods, that expect the work file to exist on disk
     :param chooser OrganizerChooser, if there's rules that are unique to a collection about file naming.
+    :param application str representation of application name, for retrieving version
     """
     if config is None:
         config = mc.Config()
@@ -586,7 +587,7 @@ def run_by_state(
 ):
     """A default implementation for using the StateRunner.
 
-    :param config Config instance
+    :param config: Config instance
     :param name_builder NameBuilder extension that creates an instance of
         a StorageName extension, from an entry from a DataSourceComposable
         listing

--- a/caom2pipe/run_composable.py
+++ b/caom2pipe/run_composable.py
@@ -337,10 +337,7 @@ class StateRunner(TodoRunner):
                     while len(entries) > 0:
                         entry = pop_action()
                         result |= self._process_entry(entry.entry_name, 0)
-                        temp_time = min(
-                            mc.convert_to_ts_tz(entry.entry_ts, self._data_source.timezone), exec_time.timestamp()
-                        )
-                        save_time = datetime.fromtimestamp(temp_time, self._data_source.timezone)
+                        save_time = min(entry.entry_dt, exec_time)
                     # this reset call is outside the while process_entry loop
                     # for GEMINI which gets all the metadata for an interval in
                     # a single call, and it wouldn't be polite to throw away

--- a/caom2pipe/tests/data/proxy.pem
+++ b/caom2pipe/tests/data/proxy.pem
@@ -1,0 +1,1 @@
+test content

--- a/caom2pipe/tests/test_manage_composable.py
+++ b/caom2pipe/tests/test_manage_composable.py
@@ -389,24 +389,24 @@ def test_make_seconds():
 def test_increment_time():
     t1 = '2017-06-26T17:07:21.527'
     t1_dt = datetime.strptime(t1, mc.ISO_8601_FORMAT)
-    result = mc.increment_time_tz(t1_dt, 10)
+    result = mc.increment_time_tz(t1_dt, 10, zone=timezone.utc)
     assert result is not None, 'expect a result'
-    assert result == datetime(2017, 6, 26, 17, 17, 21, 527000), 'wrong result'
+    assert result == datetime(2017, 6, 26, 17, 17, 21, 527000, tzinfo=timezone.utc), 'wrong result'
 
     t2 = '2017-07-26T17:07:21.527'
     t2_dt = datetime.strptime(t2, mc.ISO_8601_FORMAT)
-    result = mc.increment_time_tz(t2_dt, 5)
+    result = mc.increment_time_tz(t2_dt, 5, zone=timezone.utc)
     assert result is not None, 'expect a result'
-    assert result == datetime(2017, 7, 26, 17, 12, 21, 527000), 'wrong result'
+    assert result == datetime(2017, 7, 26, 17, 12, 21, 527000, tzinfo=timezone.utc), 'wrong result'
 
     t3 = 1571595618.0
-    result = mc.increment_time_tz(t3, 15)
+    result = mc.increment_time_tz(t3, 15, zone=timezone.utc)
     assert result == datetime(
         2019, 10, 20, 18, 35, 18, tzinfo=timezone.utc
     ), 'wrong t3 result'
 
     with pytest.raises(NotImplementedError):
-        mc.increment_time_tz(t2_dt, 23, '%f')
+        mc.increment_time_tz(t2_dt, 23, timezone.utc, '%f')
 
 
 @patch('requests.get')

--- a/caom2pipe/tests/test_manage_composable.py
+++ b/caom2pipe/tests/test_manage_composable.py
@@ -69,6 +69,7 @@
 import math
 import os
 import pytest
+import traceback
 
 from datetime import datetime, timedelta, timezone
 from shutil import copy
@@ -806,7 +807,35 @@ def test_log_directory_construction(test_config, tmpdir):
     assert not os.path.exists(test_config.success_fqn)
     assert not os.path.exists(test_config.failure_fqn)
     assert not os.path.exists(test_config.retry_fqn)
-    ignore = mc.ExecutionReporter(test_config, observable=Mock(autospec=True), application='DEFAULT')
+    test_subject = mc.ExecutionReporter(test_config, observable=Mock(autospec=True), application='DEFAULT')
     assert os.path.exists(test_config.success_fqn)
     assert os.path.exists(test_config.failure_fqn)
     assert os.path.exists(test_config.retry_fqn)
+
+    try:
+        raise RuntimeError('Read timed out')
+    except Exception as e:
+        test_sname = tc.TestStorageName(obs_id='test_obs_id_2')
+        test_subject.capture_failure(test_sname, e, traceback.format_exc())
+
+    try:
+        raise RuntimeError('some other error')
+    except Exception as e2:
+        test_sname = tc.TestStorageName(obs_id='test_obs_id')
+        test_subject.capture_failure(test_sname, e2, traceback.format_exc())
+
+    test_subject.capture_success('test_obs_id', 'C121212_01234_CAL.fits.gz', datetime.utcnow().timestamp())
+    test_subject.report()
+
+    success_content = open(test_config.success_fqn).read()
+    assert 'test_obs_id C121212_01234_CAL.fits.gz' in success_content, 'wrong content'
+    retry_content = open(test_config.retry_fqn).read()
+    assert retry_content == '/tmp/test_file.fits.gz\n/tmp/test_file.fits.gz\n', f'{retry_content}'
+    failure_content = open(test_config.failure_fqn).read()
+    assert failure_content.endswith('some other error\n'), failure_content
+    assert os.path.exists(test_config.rejected_fqn), test_config.rejected_fqn
+    rejected_content = mc.read_as_yaml(test_config.rejected_fqn)
+    assert rejected_content is not None, 'expect a result'
+    test_result = rejected_content.get('bad_metadata')
+    assert test_result is not None, 'wrong result'
+    assert len(test_result) == 0, f'wrong number of entries {test_result}'

--- a/caom2pipe/tests/test_reporting.py
+++ b/caom2pipe/tests/test_reporting.py
@@ -80,7 +80,7 @@ specializations.
 import logging
 
 
-from datetime import datetime
+from datetime import datetime, timezone
 from os import chdir, getcwd
 
 from cadcdata import FileInfo
@@ -94,8 +94,8 @@ from unittest.mock import call, Mock, patch
 from test_data_source_composable import _create_dir_listing
 from test_run_composable import TEST_BOOKMARK, _write_state
 
-TEST_START_TIME = datetime(year=2020, month=3, day=3, hour=1, minute=1, second=1)
-TEST_END_TIME = datetime(year=2020, month=3, day=3, hour=2, minute=1, second=1)
+TEST_START_TIME = datetime(year=2020, month=3, day=3, hour=1, minute=1, second=1, tzinfo=timezone.utc)
+TEST_END_TIME = datetime(year=2020, month=3, day=3, hour=2, minute=1, second=1, tzinfo=timezone.utc)
 
 
 def test_report_output_todo_local(test_config, tmpdir):

--- a/caom2pipe/tests/test_run_composable.py
+++ b/caom2pipe/tests/test_run_composable.py
@@ -1085,7 +1085,12 @@ def _mock_query(arg1, arg2, arg3):
     global call_count
     if call_count == 0:
         call_count = 1
-        temp.append(dsc.StateRunnerMeta('NEOS_SCI_2015347000000_clean.fits', '2019-10-23T16:27:19.000'))
+        temp.append(
+            dsc.StateRunnerMeta(
+                'NEOS_SCI_2015347000000_clean.fits',
+                datetime.strptime('2019-10-23T16:27:19.000', '%Y-%m-%dT%H:%M:%S.%f').astimezone(timezone.utc),
+            )
+        )
         return temp
     return temp
 

--- a/caom2pipe/tests/test_run_composable.py
+++ b/caom2pipe/tests/test_run_composable.py
@@ -220,7 +220,7 @@ def test_run_state(
     # tap_mock is used by the data_source_composable class
     visit_meta_mock.side_effect = _mock_visit
     clients_mock.return_value.metadata_client.read.side_effect = _mock_read2
-    tap_query_mock.side_effect = _mock_get_work
+    tap_query_mock.side_effect = _mock_query_table2
 
     test_end_time = datetime.fromtimestamp(1579740838, tz=timezone.utc)
     start_time = test_end_time - timedelta(seconds=900)
@@ -309,7 +309,7 @@ def test_run_state_log_to_file_true(
         )
     )
     visit_meta_mock.side_effect = _mock_visit
-    tap_mock.side_effect = _mock_get_work
+    tap_mock.side_effect = _mock_query_table2
 
     test_end_time = datetime.fromtimestamp(1579740838, tz=tz.UTC)
     start_time = test_end_time - timedelta(seconds=900)
@@ -406,8 +406,8 @@ def test_run_todo_retry(do_one_mock, clients_mock, source_mock, test_config, tmp
     test_config.retry_failures = True
     test_config.retry_decay = 0
     _write_todo(test_config)
-    retry_success_fqn = f'{tmpdir}/logs_0/' f'{test_config.success_log_file_name}'
-    retry_failure_fqn = f'{tmpdir}/logs_0/' f'{test_config.failure_log_file_name}'
+    retry_success_fqn = f'{tmpdir}/logs_0/{test_config.success_log_file_name}'
+    retry_failure_fqn = f'{tmpdir}/logs_0/{test_config.failure_log_file_name}'
     retry_retry_fqn = f'{tmpdir}/logs_0/{test_config.retry_file_name}'
     do_one_mock.side_effect = _mock_do_one
 
@@ -453,37 +453,33 @@ def test_run_todo_retry(do_one_mock, clients_mock, source_mock, test_config, tmp
     source_mock.assert_called_with('test_obs_id.fits.gz', 0, 0)
 
 
+@patch('caom2pipe.client_composable.ClientCollection', autospec=True)
 @patch('caom2pipe.execute_composable.OrganizeExecutes.do_one')
-@patch('caom2pipe.data_source_composable.CadcTapClient')
+@patch('caom2pipe.data_source_composable.CadcTapClient', autospec=True)
 @patch(
     'caom2pipe.data_source_composable.QueryTimeBoxDataSource.'
     'get_time_box_work'
 )
-@pytest.mark.skip('')
-def test_run_state_retry(get_work_mock, tap_mock, do_one_mock, test_config):
-    _write_state(rc.get_utc_now_tz())
-    (
-        retry_success_fqn,
-        retry_failure_fqn,
-        retry_retry_fqn,
-    ) = _clean_up_log_files(test_config)
+def test_run_state_retry(get_work_mock, tap_mock, do_one_mock, clients_mock, test_config, tmpdir):
+    test_config.change_working_directory(tmpdir)
+    _write_state(rc.get_now_tz(timezone.utc), test_config.state_fqn)
+    retry_success_fqn = f'{tmpdir}/logs_0/{test_config.success_log_file_name}'
+    retry_failure_fqn = f'{tmpdir}/logs_0/{test_config.failure_log_file_name}'
+    retry_retry_fqn = f'{tmpdir}/logs_0/{test_config.retry_file_name}'
+
     global call_count
     call_count = 0
-    # get_work_mock.return_value.get_time_box_work.side_effect = _mock_get_work
     get_work_mock.side_effect = _mock_get_work
     do_one_mock.side_effect = _mock_do_one
 
     test_config.log_to_file = True
     test_config.retry_failures = True
-    test_config.state_fqn = STATE_FILE
+    test_config.retry_count = 1
+    test_config.retry_decay = 0
     test_config.interval = 10
     test_config.logging_level = 'DEBUG'
 
-    test_result = rc.run_by_state(
-        config=test_config,
-        command_name=TEST_COMMAND,
-        bookmark_name=TEST_BOOKMARK,
-    )
+    test_result = rc.run_by_state(config=test_config, bookmark_name=TEST_BOOKMARK)
 
     assert test_result is not None, 'expect a result'
     assert test_result == -1, 'expect failure'
@@ -498,69 +494,6 @@ def test_run_state_retry(get_work_mock, tap_mock, do_one_mock, test_config):
     assert tap_mock.called, 'init should be called'
 
 
-# TODO - make this work with TodoRunner AND StateRunner
-# for the 'finish_run' call
-@pytest.mark.skip('')
-def test_capture_failure(test_config):
-    start_s = datetime.utcnow().timestamp()
-    test_obs_id = 'test_obs_id'
-    test_obs_id_2 = 'test_obs_id_2'
-    log_file_directory = os.path.join(tc.THIS_DIR, 'logs')
-    test_config.log_to_file = True
-    test_config.log_file_directory = log_file_directory
-    success_log_file_name = 'success_log.txt'
-    test_config.success_log_file_name = success_log_file_name
-    failure_log_file_name = 'failure_log.txt'
-    test_config.failure_log_file_name = failure_log_file_name
-    retry_file_name = 'retries.txt'
-    test_config.retry_file_name = retry_file_name
-    rejected_file_name = 'rejected.yml'
-    test_config.rejected_file_name = rejected_file_name
-
-    # clean up from last execution
-    if not os.path.exists(log_file_directory):
-        os.mkdir(log_file_directory)
-    if os.path.exists(test_config.success_fqn):
-        os.remove(test_config.success_fqn)
-    if os.path.exists(test_config.failure_fqn):
-        os.remove(test_config.failure_fqn)
-    if os.path.exists(test_config.retry_fqn):
-        os.remove(test_config.retry_fqn)
-    if os.path.exists(test_config.rejected_fqn):
-        os.remove(test_config.rejected_fqn)
-
-    test_oe = ec.OrganizeExecutesWithDoOne(test_config, 'command', [], [])
-    test_sname = tc.TestStorageName(obs_id=test_obs_id_2)
-    test_oe.capture_failure(test_sname, 'Cannot build an observation')
-    test_sname = tc.TestStorageName(obs_id=test_obs_id)
-    test_oe.capture_failure(test_sname, 'exception text')
-    test_oe.capture_success(test_obs_id, 'C121212_01234_CAL.fits.gz', start_s)
-    test_oe.finish_run(test_config)
-
-    assert os.path.exists(test_config.success_fqn)
-    assert os.path.exists(test_config.failure_fqn)
-    assert os.path.exists(test_config.retry_fqn)
-    assert os.path.exists(test_config.rejected_fqn)
-
-    success_content = open(test_config.success_fqn).read()
-    assert (
-        'test_obs_id C121212_01234_CAL.fits.gz' in success_content
-    ), 'wrong content'
-    retry_content = open(test_config.retry_fqn).read()
-    assert retry_content == 'test_obs_id\n'
-    failure_content = open(test_config.failure_fqn).read()
-    assert failure_content.endswith(
-        'Unknown error. Check specific log.\n'
-    ), failure_content
-    assert os.path.exists(test_config.rejected_fqn), test_config.rejected_fqn
-    rejected_content = mc.read_as_yaml(test_config.rejected_fqn)
-    assert rejected_content is not None, 'expect a result'
-    test_result = rejected_content.get('bad_metadata')
-    assert test_result is not None, 'wrong result'
-    assert len(test_result) == 1, 'wrong number of entries'
-    assert test_result[0] == test_obs_id, 'wrong entry'
-
-
 @patch('caom2pipe.client_composable.ClientCollection', autospec=True)
 def test_time_box(clients_mock, test_config, tmpdir):
     # test that the time boxes increment as expected, to a maximum value
@@ -571,15 +504,15 @@ def test_time_box(clients_mock, test_config, tmpdir):
 
     test_config.interval = 700
 
-    for test_timezone in [timezone.utc, tz.gettz('US/Mountain')]:
-
-        _write_state('23-Jul-2019 09:51', test_config.state_fqn)
-        test_end_time = datetime(2019, 7, 24, 9, 20, tzinfo=test_timezone)
+    for test_tz in [timezone.utc, tz.gettz('US/Mountain')]:
+        test_start_time = datetime(2019, 7, 23, 9, 51, tzinfo=test_tz)
+        _write_state(test_start_time, test_config.state_fqn)
+        test_end_time = datetime(2019, 7, 24, 9, 20, tzinfo=test_tz)
 
         class MakeTimeBoxWork(dsc.DataSource):
 
             def __init__(self):
-                super().__init__(test_config, test_timezone)
+                super().__init__(test_config, test_tz)
                 self.todo_call_count = 0
                 self.zero_called = False
                 self.one_called = False
@@ -587,21 +520,16 @@ def test_time_box(clients_mock, test_config, tmpdir):
 
             def get_time_box_work(self, prev_exec_dt, exec_dt):
                 if self.todo_call_count == 0:
-                    test_p_time = datetime(2019, 7, 23, 9, 51, tzinfo=timezone.utc).astimezone(test_timezone)
-                    assert prev_exec_dt == test_p_time, f'wrong prev 0 {test_timezone} {prev_exec_dt} {test_p_time}'
-                    test_e_time = datetime(2019, 7, 23, 21, 31, tzinfo=timezone.utc).astimezone(test_timezone)
-                    assert exec_dt == test_e_time, 'wrong exec 0'
+                    assert prev_exec_dt == datetime(2019, 7, 23, 9, 51, tzinfo=test_tz), f'prev 0 {test_tz}'
+                    assert exec_dt == datetime(2019, 7, 23, 21, 31, tzinfo=test_tz), 'wrong exec 0'
                     self.zero_called = True
                 elif self.todo_call_count == 1:
-                    test_p_time = datetime(2019, 7, 23, 21, 31, tzinfo=timezone.utc).astimezone(test_timezone)
-                    test_e_time = datetime(2019, 7, 24, 9, 11, tzinfo=timezone.utc).astimezone(test_timezone)
-                    assert prev_exec_dt == test_p_time, 'wrong prev 1'
-                    assert exec_dt == test_e_time, 'wrong exec 1'
+                    assert prev_exec_dt == datetime(2019, 7, 23, 21, 31, tzinfo=test_tz), 'wrong prev 1'
+                    assert exec_dt == datetime(2019, 7, 24, 9, 11, tzinfo=test_tz), 'wrong exec 1'
                     self.one_called = True
                 elif self.todo_call_count == 2:
-                    test_p_time = datetime(2019, 7, 24, 9, 11, tzinfo=timezone.utc).astimezone(test_timezone)
-                    assert prev_exec_dt == test_p_time, 'wrong exec 2'
-                    assert exec_dt == test_end_time, f'wrong exec 2 {test_timezone}'
+                    assert prev_exec_dt == datetime(2019, 7, 24, 9, 11, tzinfo=test_tz), 'wrong exec 2'
+                    assert exec_dt == test_end_time, f'wrong exec 2 {test_tz}'
                     self.two_called = True
                 self.todo_call_count += 1
                 assert self.todo_call_count <= 4, 'loop is written wrong'
@@ -626,88 +554,85 @@ def test_time_box(clients_mock, test_config, tmpdir):
         assert test_work.todo_call_count == 3, 'wrong todo call count'
 
 
-def test_time_box_equal(test_config):
-    _write_state('23-Jul-2019 09:51')
-    test_config.state_fqn = STATE_FILE
+@patch('caom2pipe.client_composable.ClientCollection', autospec=True)
+def test_time_box_equal(clients_mock, test_config, tmpdir):
+    # test that if the end datetime is the same as the start datetime, there are no calls
+    test_config.change_working_directory(tmpdir)
     test_config.interval = 700
 
-    class MakeWork(mc.Work):
+    for test_timezone in [timezone.utc, tz.gettz('US/Mountain')]:
+        test_start_time = test_end_time = datetime(2019, 7, 23, 9, 51, tzinfo=test_timezone)
+        _write_state(test_start_time, test_config.state_fqn)
 
-        def __init__(self):
-            super(MakeWork, self).__init__(
-                mc.make_seconds('23-Jul-2019 09:51'))
-            self.todo_call_count = 0
-            self.zero_called = False
-            self.one_called = False
-            self.two_called = False
+        class MakeWork(dsc.DataSource):
 
-        def initialize(self):
-            pass
+            def __init__(self):
+                super().__init__(test_config, test_timezone)
+                self.todo_call_count = 0
 
-        def todo(self, prev_exec_ts, exec_ts):
-            self.todo_call_count += 1
-            assert self.todo_call_count <= 4, 'loop is written wrong'
-            return []
+            def get_time_box_work(self, prev_exec_dt, exec_dt):
+                self.todo_call_count += 1
+                assert self.todo_call_count <= 4, 'loop is written wrong'
+                return deque()
 
-    test_work = MakeWork()
+        test_work = MakeWork()
 
-    test_result = ec.run_from_state(test_config,
-                                    sname=mc.StorageName,
-                                    command_name=COMMAND_NAME,
-                                    meta_visitors=None,
-                                    data_visitors=None,
-                                    bookmark_name=TEST_BOOKMARK,
-                                    work=test_work)
-    assert test_result is not None, 'expect a result'
-    test_state = mc.State(test_config.state_fqn)
-    assert test_state.get_bookmark(TEST_BOOKMARK) == \
-        datetime(2019, 7, 23, 9, 51)
-    assert test_work.todo_call_count == 0, 'wrong todo call count'
+        test_result = rc.run_by_state(
+            test_config,
+            meta_visitors=None,
+            data_visitors=None,
+            bookmark_name=TEST_BOOKMARK,
+            end_time=test_end_time,
+            source=test_work,
+        )
+        assert test_result is not None, 'expect a result'
+        test_state = mc.State(test_config.state_fqn)
+        assert test_state.get_bookmark(TEST_BOOKMARK) == test_end_time
+        assert test_work.todo_call_count == 0, 'wrong todo call count'
 
 
-@pytest.mark.skip('')
-def test_time_box_once_through(test_config):
-    _write_state('23-Jul-2019 09:51')
-    test_config.state_fqn = STATE_FILE
+@patch('caom2pipe.client_composable.ClientCollection', autospec=True)
+def test_time_box_once_through(clients_mock, test_config, tmpdir):
+    test_config.change_working_directory(tmpdir)
     test_config.interval = 700
 
-    # class MakeWork(mc.Work):
-    #
-    #     def __init__(self):
-    #         super(MakeWork, self).__init__(
-    #             mc.make_seconds('23-Jul-2019 12:20'))
-    #         self.todo_call_count = 0
-    #         self.zero_called = False
-    #
-    #     def initialize(self):
-    #         pass
-    #
-    #     def todo(self, prev_exec_dt, exec_dt):
-    #         if self.todo_call_count == 0:
-    #             assert prev_exec_dt == datetime(2019, 7, 23, 9, 51), \
-    #                 'wrong prev'
-    #             assert exec_dt == datetime(2019, 7, 23, 12, 20), 'wrong exec'
-    #             self.zero_called = True
-    #         self.todo_call_count += 1
-    #         assert self.todo_call_count <= 4, 'loop is written wrong'
-    #         return []
-    #
-    # test_work = MakeWork()
-    #
-    # test_result = ec.run_from_state(test_config,
-    #                                 sname=mc.StorageName,
-    #                                 command_name=COMMAND_NAME,
-    #                                 meta_visitors=None,
-    #                                 data_visitors=None,
-    #                                 bookmark_name=TEST_BOOKMARK,
-    #                                 work=test_work)
-    # assert test_result is not None, 'expect a result'
-    #
-    # test_state = mc.State(test_config.state_fqn)
-    # assert test_work.zero_called, 'missed zero'
-    # assert test_state.get_bookmark(TEST_BOOKMARK) == \
-    #     datetime(2019, 7, 23, 12, 20)
-    # assert test_work.todo_call_count == 1, 'wrong todo call count'
+    for test_timezone in [timezone.utc, tz.gettz('US/Mountain')]:
+        test_start_time = datetime(2019, 7, 23, 9, 51, tzinfo=test_timezone)
+        _write_state(test_start_time, test_config.state_fqn)
+        test_end_time = datetime(2019, 7, 23, 12, 20, tzinfo=test_timezone)
+
+        class MakeWork(dsc.DataSource):
+
+            def __init__(self):
+                super().__init__(test_config, test_timezone)
+                self.todo_call_count = 0
+                self.zero_called = False
+
+            def get_time_box_work(self, prev_exec_dt, exec_dt):
+                if self.todo_call_count == 0:
+                    assert prev_exec_dt == datetime(2019, 7, 23, 9, 51, tzinfo=test_timezone), 'prev'
+                    assert exec_dt == datetime(2019, 7, 23, 12, 20, tzinfo=test_timezone), 'wrong exec'
+                    self.zero_called = True
+                self.todo_call_count += 1
+                assert self.todo_call_count <= 4, 'loop is written wrong'
+                return deque()
+
+        test_work = MakeWork()
+
+        test_result = rc.run_by_state(
+            test_config,
+            meta_visitors=None,
+            data_visitors=None,
+            bookmark_name=TEST_BOOKMARK,
+            source=test_work,
+            end_time=test_end_time,
+        )
+        assert test_result is not None, 'expect a result'
+
+        test_state = mc.State(test_config.state_fqn)
+        assert test_work.zero_called, 'missed zero'
+        assert test_state.get_bookmark(TEST_BOOKMARK) == test_end_time
+        assert test_work.todo_call_count == 1, 'wrong todo call count'
 
 
 @patch('caom2pipe.execute_composable.CaomExecute._caom2_store')
@@ -1088,27 +1013,6 @@ def test_store_from_to_cadc(clients_mock, get_work_mock, test_config):
     ), 'wrong put params'
 
 
-def _clean_up_log_files(test_config):
-    retry_success_fqn = (
-        f'{tc.TEST_DATA_DIR}_0/' f'{test_config.success_log_file_name}'
-    )
-    retry_failure_fqn = (
-        f'{tc.TEST_DATA_DIR}_0/' f'{test_config.failure_log_file_name}'
-    )
-    retry_retry_fqn = f'{tc.TEST_DATA_DIR}_0/{test_config.retry_file_name}'
-    for ii in [
-        test_config.success_fqn,
-        test_config.failure_fqn,
-        test_config.retry_fqn,
-        retry_failure_fqn,
-        retry_retry_fqn,
-        retry_success_fqn,
-    ]:
-        if os.path.exists(ii):
-            os.unlink(ii)
-    return retry_success_fqn, retry_failure_fqn, retry_retry_fqn
-
-
 def _check_log_files(
     test_config, retry_success_fqn, retry_failure_fqn, retry_retry_fqn
 ):
@@ -1158,11 +1062,11 @@ def _mock_get_work(arg1, arg2):
     return _mock_query(None, None, None)
 
 
-def _mock_get_work2(arg1, **kwargs):
-    return _mock_query(None, None, None)
+def _mock_query_table2(arg1, arg2):
+    return _mock_query_table(None, None, None)
 
 
-def _mock_query(arg1, arg2, arg3):
+def _mock_query_table(arg1, arg2, arg3):
     global call_count
     if call_count == 0:
         call_count = 1
@@ -1174,6 +1078,16 @@ def _mock_query(arg1, arg2, arg3):
         )
     else:
         return Table.read('fileName,ingestDate\n'.split('\n'), format='csv')
+
+
+def _mock_query(arg1, arg2, arg3):
+    temp = deque()
+    global call_count
+    if call_count == 0:
+        call_count = 1
+        temp.append(dsc.StateRunnerMeta('NEOS_SCI_2015347000000_clean.fits', '2019-10-23T16:27:19.000'))
+        return temp
+    return temp
 
 
 def _mock_do_one(arg1):

--- a/caom2pipe/tests/test_state.py
+++ b/caom2pipe/tests/test_state.py
@@ -113,8 +113,9 @@ class TestListDirTimeBoxDataSource(dsc.DataSource):
         file_list = glob.glob('/caom2pipe_test/*')
         for entry in file_list:
             stats = os.stat(entry)
-            if prev_exec_time <= stats.st_mtime <= exec_time:
-                self._work.append(dsc.StateRunnerMeta(entry, stats.st_mtime))
+            entry_st_mtime_dt = datetime.fromtimestamp(stats.st_mtime, tz=self._timezone)
+            if prev_exec_time <= entry_st_mtime_dt <= exec_time:
+                self._work.append(dsc.StateRunnerMeta(entry, entry_st_mtime_dt))
         self._capture_todo()
         return self._work
 

--- a/caom2pipe/validator_composable.py
+++ b/caom2pipe/validator_composable.py
@@ -145,14 +145,14 @@ class Validator:
         import pandas as pd
         newer = pd.DataFrame()
         if len(data) > 0:
-            # SG - 08-09-22 - All timestamps in the SI databases are in UT.
+            # SG - 08-09-22 - All times in the SI databases are in UTC.
             #
-            # source_temp => url, timestamp, f_name
+            # source_temp => url, dt, f_name
             # data => uri, contentLastModified
             data['f_name'] = data.uri.apply(Validator.filter_column)
-            data['ts'] = data.contentLastModified.apply(pd.to_datetime)
+            data['dt_d'] = data.contentLastModified.apply(Validator.make_utc_aware)
             merged = pd.merge(source, data, how='inner', on=['f_name'])
-            newer = merged[merged.timestamp > merged.ts]
+            newer = merged[merged.dt_d > merged.dt]
         return newer
 
     def _read_list_from_destination_data(self):
@@ -234,6 +234,6 @@ class Validator:
         return in_here[~in_here[column].isin(from_there[column])]
 
     @staticmethod
-    def make_timestamp(a):
+    def make_utc_aware(a):
         import pandas as pd
-        return pd.to_datetime(a)
+        return pd.to_datetime(a, utc=True)


### PR DESCRIPTION
because timestamp is calculated as seconds since 1970, 1, 1 in UTC.